### PR TITLE
DELTASPIKE-370 - Conditional tests based on CDI Impl version range

### DIFF
--- a/deltaspike/cdictrl/impl-weld/pom.xml
+++ b/deltaspike/cdictrl/impl-weld/pom.xml
@@ -57,6 +57,12 @@
             <artifactId>geronimo-jta_1.1_spec</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.deltaspike.test</groupId>
+            <artifactId>test-utils</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/deltaspike/cdictrl/tck/pom.xml
+++ b/deltaspike/cdictrl/tck/pom.xml
@@ -82,6 +82,14 @@
             <artifactId>deltaspike-cdictrl-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.deltaspike.test</groupId>
+            <artifactId>test-utils</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/deltaspike/cdictrl/tck/src/main/java/org/apache/deltaspike/cdise/tck/ContainerCtrlTckTest.java
+++ b/deltaspike/cdictrl/tck/src/main/java/org/apache/deltaspike/cdise/tck/ContainerCtrlTckTest.java
@@ -19,24 +19,34 @@
 package org.apache.deltaspike.cdise.tck;
 
 
+import java.util.Set;
+
+import javax.enterprise.context.ContextNotActiveException;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+
 import org.apache.deltaspike.cdise.api.CdiContainer;
 import org.apache.deltaspike.cdise.api.CdiContainerLoader;
 import org.apache.deltaspike.cdise.tck.beans.Car;
 import org.apache.deltaspike.cdise.tck.beans.CarRepair;
 import org.apache.deltaspike.cdise.tck.beans.TestUser;
+import org.apache.deltaspike.cdise.tck.control.LockedCDIImplementation;
+import org.apache.deltaspike.cdise.tck.control.LockedVersionRange;
+import org.apache.deltaspike.cdise.tck.control.VersionControlRule;
+import org.apache.deltaspike.test.utils.CdiImplementation;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
-
-import javax.enterprise.context.ContextNotActiveException;
-import javax.enterprise.inject.spi.Bean;
-import javax.enterprise.inject.spi.BeanManager;
-import java.util.Set;
 
 /**
  * TCK test for the {@link org.apache.deltaspike.cdise.api.CdiContainer}
  */
 public class ContainerCtrlTckTest
 {
+
+    @Rule
+    public VersionControlRule versionControlRule = new VersionControlRule();
+
     @Test
     public void testContainerBoot()
     {
@@ -158,6 +168,10 @@ public class ContainerCtrlTckTest
     }
 
     @Test
+    @LockedCDIImplementation(versions = {
+            @LockedVersionRange(implementation = CdiImplementation.WELD11, versionRange = "[1.1.14,1.2)"),
+            @LockedVersionRange(implementation = CdiImplementation.WELD20, versionRange = "[2.0.1.Final,2.1)")
+            })
     public void testShutdownWithInactiveContexts()
     {
         CdiContainer cdiContainer = CdiContainerLoader.getCdiContainer();

--- a/deltaspike/cdictrl/tck/src/main/java/org/apache/deltaspike/cdise/tck/control/LockedCDIImplementation.java
+++ b/deltaspike/cdictrl/tck/src/main/java/org/apache/deltaspike/cdise/tck/control/LockedCDIImplementation.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.deltaspike.cdise.tck.control;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.apache.deltaspike.test.utils.CdiImplementation;
+
+/**
+ * This annotation is used to define the {@link #cdiImplementations()} which the test is allowed to run. 
+ * 
+ * If {@link #cdiImplementations()} is not defined, It will be used all available implementations 
+ * defined on {@link CdiImplementation}.
+ * 
+ * An specific implementation can have {@link #versions()} range locked throught the use of {@link LockedVersionRange}
+ * @author rafaelbenevides
+ *
+ */
+@Target(value = { ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LockedCDIImplementation
+{
+
+    CdiImplementation[] cdiImplementations() default { CdiImplementation.OWB11, CdiImplementation.OWB12,
+            CdiImplementation.WELD11, CdiImplementation.WELD12, CdiImplementation.WELD20 };
+
+    LockedVersionRange[] versions() default { };
+}

--- a/deltaspike/cdictrl/tck/src/main/java/org/apache/deltaspike/cdise/tck/control/LockedContainerVersions.java
+++ b/deltaspike/cdictrl/tck/src/main/java/org/apache/deltaspike/cdise/tck/control/LockedContainerVersions.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.deltaspike.cdise.tck.control;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(value = { ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LockedContainerVersions
+{
+
+}

--- a/deltaspike/cdictrl/tck/src/main/java/org/apache/deltaspike/cdise/tck/control/LockedVersionRange.java
+++ b/deltaspike/cdictrl/tck/src/main/java/org/apache/deltaspike/cdise/tck/control/LockedVersionRange.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.deltaspike.cdise.tck.control;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.apache.deltaspike.test.utils.CdiImplementation;
+
+/**
+ * It allows to specify the version range that the test is allowed to run for an specified {@link #implementation()}.
+ * 
+ * The {@link #versionRange()} attribute uses the Maven version range pattern
+ * @author rafaelbenevides
+ *
+ */
+@Target(value = { ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LockedVersionRange
+{
+
+    CdiImplementation implementation();
+
+    String versionRange();
+
+}

--- a/deltaspike/cdictrl/tck/src/main/java/org/apache/deltaspike/cdise/tck/control/VersionControlRule.java
+++ b/deltaspike/cdictrl/tck/src/main/java/org/apache/deltaspike/cdise/tck/control/VersionControlRule.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.deltaspike.cdise.tck.control;
+
+import org.apache.deltaspike.test.utils.CdiContainerUnderTest;
+import org.apache.deltaspike.test.utils.CdiImplementation;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+
+/** 
+ * 
+ * This {@link TestRule} allows an test to check those methods annotated with {@link LockedCDIImplementation}.
+ * 
+ * You can define some {@link LockedCDIImplementation}. Example: 
+ * 
+ * <pre>
+ *     @LockedCDIImplementation(cdiImplementations = {
+ *           CdiImplementation.OWB11,
+ *           CdiImplementation.OWB12
+ *   })
+ * </pre>
+ *  
+ * 
+ * You can also define specific versions of an specific implementation. Example:
+ * 
+ * <pre>
+ *     @LockedCDIImplementation(versions = {
+ *           @LockedVersionRange(implementation = CdiImplementation.WELD11, versionRange = "[1.1.13,1.2)"),
+ *           @LockedVersionRange(implementation = CdiImplementation.WELD20, versionRange = "[2.0.1.Final,2.1)")
+ *           })
+ * </pre>
+ * 
+ * @author rafaelbenevides
+ *
+ */
+public class VersionControlRule implements TestRule
+{
+
+    @Override
+    public Statement apply(final Statement base, final Description description)
+    {
+        return new Statement()
+        {
+
+            @Override
+            public void evaluate() throws Throwable
+            {
+                LockedCDIImplementation lockedCDIImplAnnotation = description
+                        .getAnnotation(LockedCDIImplementation.class);
+                // no @LockedCDIImplementation present or if running specified Container
+                if (lockedCDIImplAnnotation == null)
+                {
+                    base.evaluate();
+                }
+                else
+                {
+                    checkAnnotation(lockedCDIImplAnnotation, base);
+                }
+            }
+
+            private void checkAnnotation(LockedCDIImplementation lockedCDIImplAnnotation, Statement base)
+                throws Throwable
+            {
+                CdiImplementation[] implementations = lockedCDIImplAnnotation.cdiImplementations();
+                for (CdiImplementation cdiImpl : implementations)
+                {
+                    String versionRange = getLockedVersionRange(lockedCDIImplAnnotation, cdiImpl);
+                    if (CdiContainerUnderTest.isCdiVersion(cdiImpl, versionRange))
+                    {
+                        base.evaluate();
+                    }
+                }
+            }
+
+            /**
+             * Get the locked version Range
+             * 
+             * @param lockedCDIImplAnnotation
+             * @param cdiImpl
+             * @return the locked version range
+             */
+            private String getLockedVersionRange(LockedCDIImplementation lockedCDIImplAnnotation,
+                    CdiImplementation cdiImpl)
+            {
+                LockedVersionRange[] versions = lockedCDIImplAnnotation.versions();
+                for (LockedVersionRange versionRange : versions)
+                {
+                    if (versionRange.implementation().equals(cdiImpl))
+                    {
+                        return versionRange.versionRange();
+                    }
+                }
+                return null;
+            }
+        };
+    }
+}

--- a/deltaspike/parent/pom.xml
+++ b/deltaspike/parent/pom.xml
@@ -86,6 +86,7 @@
         <maven.checkstyle.plugin.version>2.9.1</maven.checkstyle.plugin.version>
         <maven.compiler.plugin.version>2.5</maven.compiler.plugin.version>
         <maven.assembly.plugin.version>2.4</maven.assembly.plugin.version>
+        <maven.artifact.version>3.0</maven.artifact.version>
 
         <hamcrest.version>1.3</hamcrest.version>
 

--- a/deltaspike/test-utils/pom.xml
+++ b/deltaspike/test-utils/pom.xml
@@ -47,6 +47,12 @@
             <artifactId>arquillian-container-test-spi</artifactId>
             <version>${arquillian.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>${maven.artifact.version}</version>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/deltaspike/test-utils/src/main/java/org/apache/deltaspike/test/utils/CdiImplementation.java
+++ b/deltaspike/test-utils/src/main/java/org/apache/deltaspike/test/utils/CdiImplementation.java
@@ -20,20 +20,20 @@ package org.apache.deltaspike.test.utils;
 
 public enum CdiImplementation
 {
-    OWB11 ("org.apache.webbeans.container.BeanManagerImpl", "1\\.1\\..*"),
-    OWB12 ("org.apache.webbeans.container.BeanManagerImpl", "1\\.2\\..*"),
+    OWB11 ("org.apache.webbeans.container.BeanManagerImpl", "[1.1,1.2)"),
+    OWB12 ("org.apache.webbeans.container.BeanManagerImpl", "[1.2,1.3)"),
 
-    WELD11("org.jboss.weld.manager.BeanManagerImpl", "1\\.1\\..*"),
-    WELD12("org.jboss.weld.manager.BeanManagerImpl", "1\\.2\\..*"),
-    WELD20("org.jboss.weld.manager.BeanManagerImpl", "2\\.0\\..*");
+    WELD11("org.jboss.weld.manager.BeanManagerImpl", "[1.1,1.2)"),
+    WELD12("org.jboss.weld.manager.BeanManagerImpl", "[1.2,1.3)"),
+    WELD20("org.jboss.weld.manager.BeanManagerImpl", "[2.0,2.1)");
 
     private final String implementationClassName;
-    private final String versionRegex;
+    private final String versionRange;
 
-    CdiImplementation(String implementationClassName, String versionRegex)
+    CdiImplementation(String implementationClassName, String versionRange)
     {
         this.implementationClassName = implementationClassName;
-        this.versionRegex = versionRegex;
+        this.versionRange = versionRange;
     }
 
     public String getImplementationClassName()
@@ -41,8 +41,8 @@ public enum CdiImplementation
         return implementationClassName;
     }
 
-    public String getVersionRegex()
+    public String getVersionRange()
     {
-        return versionRegex;
+        return versionRange;
     }
 }


### PR DESCRIPTION
Implementation of TestRule that uses Annotation to skip tests based on Impl Version.

The syntax of the annotation:

``` java
@LockedCDIImplementation(versions = {
      @LockedVersionRange(implementation = CdiImplementation.WELD11, versionRange = "[1.1.13,1.2)"),
      @LockedVersionRange(implementation = CdiImplementation.WELD20, versionRange = "[2.0.1.Final,2.1)")
})
```

Please, also check that I removed `test-utils` from cdctrl-api but I had to add it to `impl-weld` and `cdctrl-tck`
