### PR TITLE
DELTASPIKE-680 Lazy init should not rely on BeanManagerProvider

### DIFF
--- a/deltaspike/core/api/src/main/java/org/apache/deltaspike/core/api/provider/BeanProvider.java
+++ b/deltaspike/core/api/src/main/java/org/apache/deltaspike/core/api/provider/BeanProvider.java
@@ -305,6 +305,12 @@ public final class BeanProvider
     public static <T> DependentProvider<T> getDependent(Class<T> type, Annotation... qualifiers)
     {
         BeanManager beanManager = getBeanManager();
+        return getDependent(beanManager, type, qualifiers);
+    }
+
+    public static <T> DependentProvider<T> getDependent(BeanManager beanManager, Class<T> type, 
+        Annotation... qualifiers)
+    {
         Set<Bean<?>> beans = beanManager.getBeans(type, qualifiers);
         Bean<?> bean = beanManager.resolve(beans);
         return createDependentProvider(beanManager, type, (Bean<T>) bean);
@@ -326,7 +332,7 @@ public final class BeanProvider
         CreationalContext<T> cc = beanManager.createCreationalContext(bean);
         T instance = (T) beanManager.getReference(bean, type, cc);
 
-        return new DependentProvider<T>(bean, cc, instance);
+        return new DependentProvider<T>(beanManager, bean, cc, instance);
     }
 
     /**
@@ -348,7 +354,7 @@ public final class BeanProvider
         return getBeanDefinitions(type, optional, includeDefaultScopedBeans, beanManager);
     }
     
-    private static <T> Set<Bean<T>> getBeanDefinitions(Class<T> type,
+    public static <T> Set<Bean<T>> getBeanDefinitions(Class<T> type,
                                                        boolean optional,
                                                        boolean includeDefaultScopedBeans,
                                                        BeanManager beanManager)

--- a/deltaspike/core/api/src/main/java/org/apache/deltaspike/core/api/provider/DependentProvider.java
+++ b/deltaspike/core/api/src/main/java/org/apache/deltaspike/core/api/provider/DependentProvider.java
@@ -18,15 +18,17 @@
  */
 package org.apache.deltaspike.core.api.provider;
 
-import javax.enterprise.context.spi.CreationalContext;
-import javax.enterprise.inject.spi.Bean;
-import javax.enterprise.inject.spi.PassivationCapable;
-import javax.inject.Provider;
 import java.io.IOException;
 import java.io.NotSerializableException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.PassivationCapable;
+import javax.inject.Provider;
 
 /**
  * A {@link Provider} for &#064;Dependent scoped contextual instances.
@@ -45,9 +47,12 @@ public class DependentProvider<T> implements Provider<T>, Serializable
     private T instance;
     private CreationalContext<T> creationalContext;
     private transient Bean<T> bean;
+    private transient BeanManager beanManager;
 
-    DependentProvider(Bean<T> bean, CreationalContext<T> creationalContext, T instance)
+    DependentProvider(BeanManager beanManager, Bean<T> bean, 
+        CreationalContext<T> creationalContext, T instance)
     {
+        this.beanManager = beanManager;
         this.bean = bean;
         this.creationalContext = creationalContext;
         this.instance = instance;
@@ -66,7 +71,11 @@ public class DependentProvider<T> implements Provider<T>, Serializable
      */
     public void destroy()
     {
-        if (!BeanManagerProvider.getInstance().getBeanManager().isNormalScope(bean.getScope()))
+        if (beanManager == null)
+        {
+            beanManager = BeanManagerProvider.getInstance().getBeanManager();
+        }
+        if (!beanManager.isNormalScope(bean.getScope()))
         {
             bean.destroy(instance, creationalContext);
         }

--- a/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/RepositoryExtension.java
+++ b/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/RepositoryExtension.java
@@ -73,7 +73,7 @@ public class RepositoryExtension implements Extension, Deactivatable
         PersistenceUnits.instance().init();
     }
 
-    <X> void processAnnotatedType(@Observes ProcessAnnotatedType<X> event)
+    <X> void processAnnotatedType(@Observes ProcessAnnotatedType<X> event, BeanManager beanManager)
     {
         if (!isActivated)
         {
@@ -87,7 +87,7 @@ public class RepositoryExtension implements Extension, Deactivatable
             {
                 log.log(Level.FINER, "getHandlerClass: Repository annotation detected on {0}",
                         event.getAnnotatedType());
-                RepositoryComponentsFactory.instance().add(repoClass);
+                RepositoryComponentsFactory.instance().add(repoClass, beanManager);
             }
             catch (RepositoryDefinitionException e)
             {

--- a/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/builder/DelegateQueryBuilder.java
+++ b/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/builder/DelegateQueryBuilder.java
@@ -71,7 +71,7 @@ public class DelegateQueryBuilder extends QueryBuilder
     private DelegateQueryHandler selectDelegate(CdiQueryInvocationContext context)
     {
         Set<Bean<DelegateQueryHandler>> beans = BeanProvider
-                .getBeanDefinitions(DelegateQueryHandler.class, true, true);
+                .getBeanDefinitions(DelegateQueryHandler.class, true, true, beanManager);
         for (Bean<DelegateQueryHandler> bean : beans)
         {
             if (contains(bean.getBeanClass(), context.getMethod()))
@@ -84,7 +84,8 @@ public class DelegateQueryBuilder extends QueryBuilder
                     context.addDestroyable(new BeanDestroyable<DelegateQueryHandler>(bean, instance, cc));
                     return instance;
                 }
-                return (DelegateQueryHandler) BeanProvider.getContextualReference(bean.getBeanClass());
+                return (DelegateQueryHandler) BeanProvider.getContextualReference(beanManager,
+                    bean.getBeanClass(), false);
             }
         }
         return null;

--- a/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/builder/QueryBuilderFactory.java
+++ b/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/builder/QueryBuilderFactory.java
@@ -26,6 +26,8 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.enterprise.inject.spi.BeanManager;
+
 import org.apache.deltaspike.core.api.provider.BeanProvider;
 import org.apache.deltaspike.core.api.provider.DependentProvider;
 import org.apache.deltaspike.data.api.QueryResult;
@@ -52,7 +54,8 @@ public class QueryBuilderFactory implements Serializable
 
     public QueryBuilder build(RepositoryMethod method, CdiQueryInvocationContext context)
     {
-        DependentProvider<QueryBuilder> builder = BeanProvider.getDependent(
+        BeanManager beanManager = method.getRepository().getBeanManager();
+        DependentProvider<QueryBuilder> builder = BeanProvider.getDependent(beanManager,
                 QueryBuilder.class, LITERALS.get(method.getMethodType()));
         context.addDestroyable(new DependentProviderDestroyable(builder));
         if (method.returns(QueryResult.class))

--- a/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/meta/RepositoryComponent.java
+++ b/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/meta/RepositoryComponent.java
@@ -34,7 +34,6 @@ import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.persistence.FlushModeType;
 
-import org.apache.deltaspike.core.api.provider.BeanManagerProvider;
 import org.apache.deltaspike.data.api.EntityManagerConfig;
 import org.apache.deltaspike.data.api.EntityManagerResolver;
 import org.apache.deltaspike.data.api.Repository;
@@ -58,12 +57,13 @@ public class RepositoryComponent
 
     private final Class<?> repoClass;
     private final RepositoryEntity entityClass;
+    private final BeanManager beanManager;
     private final Class<? extends EntityManagerResolver> entityManagerResolver;
     private final FlushModeType entityManagerFlushMode;
 
     private final Map<Method, RepositoryMethod> methods = new HashMap<Method, RepositoryMethod>();
 
-    public RepositoryComponent(Class<?> repoClass, RepositoryEntity entityClass)
+    public RepositoryComponent(Class<?> repoClass, RepositoryEntity entityClass, BeanManager beanManager)
     {
         if (entityClass == null)
         {
@@ -71,6 +71,7 @@ public class RepositoryComponent
         }
         this.repoClass = repoClass;
         this.entityClass = entityClass;
+        this.beanManager = beanManager;
         this.entityManagerResolver = extractEntityManagerResolver(repoClass);
         this.entityManagerFlushMode = extractEntityManagerFlushMode(repoClass);
     }
@@ -80,7 +81,7 @@ public class RepositoryComponent
     {
         if (entityManagerResolverIsNormalScope == null)
         {
-            init(BeanManagerProvider.getInstance().getBeanManager());
+            init(beanManager);
         }
     }
 
@@ -251,6 +252,11 @@ public class RepositoryComponent
     public String getCustomMethodPrefix()
     {
         return repoClass.getAnnotation(Repository.class).methodPrefix();
+    }
+    
+    public BeanManager getBeanManager()
+    {
+        return beanManager;
     }
 
 }

--- a/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/meta/RepositoryComponents.java
+++ b/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/meta/RepositoryComponents.java
@@ -18,17 +18,19 @@
  */
 package org.apache.deltaspike.data.impl.meta;
 
-import org.apache.deltaspike.data.impl.RepositoryDefinitionException;
-import org.apache.deltaspike.data.impl.meta.extractor.AnnotationMetadataExtractor;
-import org.apache.deltaspike.data.impl.meta.extractor.MetadataExtractor;
-import org.apache.deltaspike.data.impl.meta.extractor.TypeMetadataExtractor;
-
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import javax.enterprise.inject.spi.BeanManager;
+
+import org.apache.deltaspike.data.impl.RepositoryDefinitionException;
+import org.apache.deltaspike.data.impl.meta.extractor.AnnotationMetadataExtractor;
+import org.apache.deltaspike.data.impl.meta.extractor.MetadataExtractor;
+import org.apache.deltaspike.data.impl.meta.extractor.TypeMetadataExtractor;
 
 /**
  * Convenience class to access Repository and Repository method meta data.
@@ -51,10 +53,10 @@ public class RepositoryComponents implements Serializable
      * @param repoClass  The repo class.
      * @return {@code true} if Repository class has been added, {@code false} otherwise.
      */
-    public void add(Class<?> repoClass)
+    public void add(Class<?> repoClass, BeanManager beanManager)
     {
         RepositoryEntity entityClass = extractEntityMetaData(repoClass);
-        RepositoryComponent repo = new RepositoryComponent(repoClass, entityClass);
+        RepositoryComponent repo = new RepositoryComponent(repoClass, entityClass, beanManager);
         repos.put(repoClass, repo);
     }
 

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/builder/part/QueryRootTest.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/builder/part/QueryRootTest.java
@@ -31,8 +31,8 @@ import org.junit.Test;
 
 public class QueryRootTest
 {
-    private final RepositoryComponent repo = new RepositoryComponent(SimpleRepository.class, new RepositoryEntity(Simple.class, Long.class));
-    private final RepositoryComponent repoFetchBy = new RepositoryComponent(SimpleFetchRepository.class, new RepositoryEntity(Simple.class, Long.class));
+    private final RepositoryComponent repo = new RepositoryComponent(SimpleRepository.class, new RepositoryEntity(Simple.class, Long.class), null);
+    private final RepositoryComponent repoFetchBy = new RepositoryComponent(SimpleFetchRepository.class, new RepositoryEntity(Simple.class, Long.class), null);
 
     @Test
     public void should_create_simple_query()


### PR DESCRIPTION
RepositoryComponent now keeps a reference to the BeanManager of the defining context.
Some helper methods of BeanProvider now optionally take an explicit BeanManager parameter.