### PR TITLE
DELTASPIKE-750 Updated documentation

### DIFF
--- a/documentation/src/main/asciidoc/configuration.adoc
+++ b/documentation/src/main/asciidoc/configuration.adoc
@@ -259,12 +259,12 @@ public class MyCustomPropertyFileConfig implements PropertyFileConfig
     {
         return "myconfig.properties";
     }
-	
-	@Override
-	public boolean isOptional()
-	{
-		return false;
-	}
+
+    @Override
+    public boolean isOptional()
+    {
+        return false;
+    }
 }
 ---------------------------------------------------------------------
 

--- a/documentation/src/main/asciidoc/configuration.adoc
+++ b/documentation/src/main/asciidoc/configuration.adoc
@@ -246,6 +246,10 @@ For registering all your own property files of a certain name in your
 classpath to get picked up as `ConfigSource`s you can also provide a
 class which implements the `PropertyFileConfig` interface.
 
+The method isOptional defines if your custom config file is mandatory. 
+If it returns false, DeltaSpike will log an error message during 
+initialization if the file was not found. 
+
 [source,java]
 ---------------------------------------------------------------------
 public class MyCustomPropertyFileConfig implements PropertyFileConfig
@@ -255,6 +259,12 @@ public class MyCustomPropertyFileConfig implements PropertyFileConfig
     {
         return "myconfig.properties";
     }
+	
+	@Override
+	public boolean isOptional()
+	{
+		return false;
+	}
 }
 ---------------------------------------------------------------------
 


### PR DESCRIPTION
I shortly had a problem that was described in jira ticket 750 (no error message if a custom property file was not found). Now that it got fixed by Gerhard Petracek, I'd like to update the documentation so that future users know how to correctly implement the changes in their custom property files