### PR TITLE
DELTASPIKE-660 added OSGi requirements and capabilities for JPA 

### DIFF
--- a/deltaspike/modules/data/api/pom.xml
+++ b/deltaspike/modules/data/api/pom.xml
@@ -36,10 +36,10 @@
             org.apache.deltaspike.data.*
         </deltaspike.osgi.export.pkg>
         <deltaspike.osgi.import>
+            javax.persistence*;version="[1.1,3)",
             !org.apache.deltaspike.data.*,
             *
         </deltaspike.osgi.import>
-        <cdi.osgi.beans-managed>META-INF/beans.xml</cdi.osgi.beans-managed>
     </properties>
 
     <dependencies>

--- a/deltaspike/modules/data/impl/pom.xml
+++ b/deltaspike/modules/data/impl/pom.xml
@@ -36,10 +36,16 @@
             org.apache.deltaspike.data.impl.*
         </deltaspike.osgi.export.pkg>
         <deltaspike.osgi.import>
+            javax.persistence*;version="[1.1,3)",
             !org.apache.deltaspike.data.impl.*,
             *
         </deltaspike.osgi.import>
-        <cdi.osgi.beans-managed>META-INF/beans.xml</cdi.osgi.beans-managed>
+        <deltaspike.osgi.require.capability>
+            org.ops4j.pax.cdi.extension; filter:="(extension=pax-cdi-extension)"
+        </deltaspike.osgi.require.capability>
+        <deltaspike.osgi.provide.capability>
+            org.ops4j.pax.cdi.extension; extension=deltaspike-data-module-impl
+        </deltaspike.osgi.provide.capability>
     </properties>
 
     <build>

--- a/deltaspike/modules/jpa/api/pom.xml
+++ b/deltaspike/modules/jpa/api/pom.xml
@@ -37,11 +37,11 @@
             org.apache.deltaspike.jpa.*
         </deltaspike.osgi.export.pkg>
         <deltaspike.osgi.import>
+            javax.persistence*;version="[1.1,3)",
             javax.enterprise.inject,
             !org.apache.deltaspike.jpa.*,
             *
         </deltaspike.osgi.import>
-        <cdi.osgi.beans-managed>META-INF/beans.xml</cdi.osgi.beans-managed>
     </properties>
 
     <dependencies>

--- a/deltaspike/modules/jpa/impl/pom.xml
+++ b/deltaspike/modules/jpa/impl/pom.xml
@@ -37,10 +37,16 @@
             org.apache.deltaspike.jpa.impl.*
         </deltaspike.osgi.export.pkg>
         <deltaspike.osgi.import>
+            javax.persistence*;version="[1.1,3)",
             !org.apache.deltaspike.jpa.impl.*,
             *
         </deltaspike.osgi.import>
-        <cdi.osgi.beans-managed>META-INF/beans.xml</cdi.osgi.beans-managed>
+        <deltaspike.osgi.require.capability>
+            org.ops4j.pax.cdi.extension; filter:="(extension=pax-cdi-extension)"
+        </deltaspike.osgi.require.capability>
+        <deltaspike.osgi.provide.capability>
+            org.ops4j.pax.cdi.extension; extension=deltaspike-jpa-module-impl
+        </deltaspike.osgi.provide.capability>
     </properties>
 
     <dependencies>

--- a/deltaspike/modules/partial-bean/impl/pom.xml
+++ b/deltaspike/modules/partial-bean/impl/pom.xml
@@ -40,7 +40,12 @@
             !org.apache.deltaspike.partialbean.impl.*,
             *
         </deltaspike.osgi.import>
-        <cdi.osgi.beans-managed>META-INF/beans.xml</cdi.osgi.beans-managed>
+        <deltaspike.osgi.require.capability>
+            org.ops4j.pax.cdi.extension; filter:="(extension=pax-cdi-extension)"
+        </deltaspike.osgi.require.capability>
+        <deltaspike.osgi.provide.capability>
+            org.ops4j.pax.cdi.extension; extension=deltaspike-partial-bean-module-impl
+        </deltaspike.osgi.provide.capability>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
...and dependencies

Widened range of javax.persistence* imports to cover JPA 2.0 and JPA 2.1
, 
Supersedes and simplifies pull request #9

Tested with Pax CDI 1.0.0-SNAPSHOT, Weld 2.2.6, OpenWebBeans 1.5.0-SNAPSHOT.