### PR TITLE
DELTASPIKE-839 Refactored test deployments in data module tests

### DIFF
--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/DisabledRepositoryTest.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/DisabledRepositoryTest.java
@@ -21,6 +21,7 @@ package org.apache.deltaspike.data.impl;
 import static org.apache.deltaspike.data.test.util.TestDeployments.initDeployment;
 
 import javax.inject.Inject;
+import org.apache.deltaspike.data.test.domain.Simple;
 
 import org.apache.deltaspike.data.test.service.DisabledRepository;
 import org.apache.deltaspike.data.test.service.SimpleRepository;
@@ -43,11 +44,14 @@ public class DisabledRepositoryTest
     public static Archive<?> deployment()
     {
         WebArchive archive = initDeployment()
+                .addPackage(Simple.class.getPackage())
                 .addClasses(SimpleRepository.class,
                         RepositoryDeactivator.class,
                         DisabledRepository.class
-                )
-                .addAsWebInfResource("disabled/META-INF/apache-deltaspike.properties",
+                );
+       
+        archive.delete("WEB-INF/classes/META-INF/apache-deltaspike.properties");
+        archive.addAsWebInfResource("disabled/META-INF/apache-deltaspike.properties",
                         "classes/META-INF/apache-deltaspike.properties");
         return archive;
     }

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/audit/AuditEntityListenerTest.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/audit/AuditEntityListenerTest.java
@@ -33,7 +33,6 @@ import org.apache.deltaspike.data.test.domain.Principal;
 import org.apache.deltaspike.test.category.WebProfileCategory;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -46,7 +45,7 @@ public class AuditEntityListenerTest extends TransactionalTestCase
     {
         return initDeployment()
                 .addPackage(AuditEntityListener.class.getPackage())
-                .addAsWebInfResource("test-orm.xml", ArchivePaths.create("classes/META-INF/orm.xml"))
+                .addAsWebInfResource("test-orm.xml", "classes/META-INF/orm.xml")
                 .addPackage(AuditedEntity.class.getPackage());
     }
 

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/handler/EntityManagerTest.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/handler/EntityManagerTest.java
@@ -50,6 +50,7 @@ public class EntityManagerTest
     public static Archive<?> deployment()
     {
         return initDeployment()
+                .addPackage(Simple.class.getPackage())
                 .addClasses(SimpleRepositoryWithEntityManager.class,
                         SimpleRepositoryWithEntityManagerResolver.class,
                         QualifiedEntityManagerTestProducer.class,

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/meta/unit/OrmXmlBasedRepositoryTest.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/meta/unit/OrmXmlBasedRepositoryTest.java
@@ -32,7 +32,6 @@ import org.apache.deltaspike.data.test.service.MappedOneRepository;
 import org.apache.deltaspike.test.category.WebProfileCategory;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
@@ -45,16 +44,15 @@ public class OrmXmlBasedRepositoryTest extends TransactionalTestCase
     @Deployment
     public static Archive<?> deployment()
     {
-        return initDeployment("(.*mapped.*)|(.*test.*)")
+        return initDeployment()
                 .addClasses(MappedOneRepository.class)
                 .addAsLibraries(
                         ShrinkWrap.create(JavaArchive.class, "domain.jar")
                                 .addPackage(MappedOne.class.getPackage())
-                                .addAsResource("test-custom-orm.xml", ArchivePaths.create("META-INF/custom-orm.xml"))
+                                .addAsResource("test-custom-orm.xml", "META-INF/custom-orm.xml")
                 )
-                .addAsWebInfResource("test-mapped-persistence.xml",
-                        ArchivePaths.create("classes/META-INF/persistence.xml"))
-                .addAsWebInfResource("test-default-orm.xml", ArchivePaths.create("classes/META-INF/orm.xml"));
+                .addAsWebInfResource("test-mapped-persistence.xml", "classes/META-INF/persistence.xml")
+                .addAsWebInfResource("test-default-orm.xml", "classes/META-INF/orm.xml");
     }
 
     @Produces

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/meta/unit/PersistenceUnitsTest.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/meta/unit/PersistenceUnitsTest.java
@@ -18,33 +18,23 @@
  */
 package org.apache.deltaspike.data.impl.meta.unit;
 
-import static org.apache.deltaspike.data.test.util.TestDeployments.TEST_FILTER;
-import static org.apache.deltaspike.data.test.util.TestDeployments.addDependencies;
-import static org.apache.deltaspike.data.test.util.TestDeployments.createApiArchive;
-import static org.apache.deltaspike.data.test.util.TestDeployments.createImplPackages;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import org.apache.deltaspike.data.impl.RepositoryDefinitionException;
-import org.apache.deltaspike.data.impl.RepositoryExtension;
 import org.apache.deltaspike.data.impl.meta.RepositoryEntity;
-import org.apache.deltaspike.data.test.TransactionalTestCase;
 import org.apache.deltaspike.data.test.domain.Parent;
 import org.apache.deltaspike.data.test.domain.TeeId;
 import org.apache.deltaspike.data.test.domain.mapped.MappedOne;
 import org.apache.deltaspike.data.test.domain.mapped.MappedThree;
 import org.apache.deltaspike.data.test.domain.mapped.MappedTwo;
 import org.apache.deltaspike.data.test.service.MappedOneRepository;
-import org.apache.deltaspike.data.test.util.Logging;
+import org.apache.deltaspike.data.test.util.TestDeployments;
 import org.apache.deltaspike.test.category.WebProfileCategory;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ArchivePaths;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -58,22 +48,16 @@ public class PersistenceUnitsTest
     @Deployment
     public static Archive<?> deployment()
     {
-        Logging.reconfigure();
-        return addDependencies(ShrinkWrap
-                .create(WebArchive.class, "test.war")
-                .addClass(WebProfileCategory.class)
-                .addAsLibrary(createApiArchive())
-                .addPackages(true, TEST_FILTER, createImplPackages())
-                .addPackages(true, Parent.class.getPackage())
-                .addClasses(RepositoryExtension.class, RepositoryDefinitionException.class,
-                        TransactionalTestCase.class, MappedOneRepository.class)
+        WebArchive war = TestDeployments.initDeployment();
+        
+        war.delete("WEB-INF/classes/META-INF/persistence.xml");
+        
+        return war.addPackages(true, Parent.class.getPackage())
+                .addClasses(MappedOneRepository.class)
                 .addAsWebInfResource("test-mapped-persistence.xml",
-                        ArchivePaths.create("classes/META-INF/persistence.xml"))
-                .addAsWebInfResource("test-default-orm.xml", ArchivePaths.create("classes/META-INF/orm.xml"))
-                .addAsWebInfResource("test-custom-orm.xml", ArchivePaths.create("classes/META-INF/custom-orm.xml"))
-                .addAsWebInfResource(EmptyAsset.INSTANCE, ArchivePaths.create("beans.xml"))
-                .addAsWebInfResource("META-INF/services/javax.enterprise.inject.spi.Extension",
-                        ArchivePaths.create("classes/META-INF/services/javax.enterprise.inject.spi.Extension")));
+                        "classes/META-INF/persistence.xml")
+                .addAsWebInfResource("test-default-orm.xml", "classes/META-INF/orm.xml")
+                .addAsWebInfResource("test-custom-orm.xml", "classes/META-INF/custom-orm.xml");
     }
 
     @Test

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/tx/TransactionalQueryRunnerTest.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/tx/TransactionalQueryRunnerTest.java
@@ -51,6 +51,7 @@ public class TransactionalQueryRunnerTest
     {
         return initDeployment()
                 .addClasses(ExtendedRepositoryInterface.class)
+                .addClass(TransactionalQueryRunnerWrapper.class)
                 .addPackage(Simple.class.getPackage());
     }
 


### PR DESCRIPTION
The significant change is in TestDeployments. All the other changes are the resulting refactorings.
Also removed ArchivePaths.create calls in addAs*Resource invocations.