### PR TITLE
DELTASPIKE-876 Website navigation bar active tab highlighting broken

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -60,6 +60,7 @@
                     <attributes>
                         <!-- Site Base Dir relative path -->
                         <sitebasedir>..</sitebasedir>
+                        <docpage>documentation</docpage>
                     </attributes>
                 </configuration>
             </plugin>

--- a/documentation/src/main/asciidoc/bean-validation.adoc
+++ b/documentation/src/main/asciidoc/bean-validation.adoc
@@ -2,7 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
 
 == Overview
 The Bean Validation module provides CDI integration for bean validation. It enables the creation of CDI-aware `ConstraintValidator` methods that can use business objects (EJBs, ManagedBeans) to support validation needs.

--- a/documentation/src/main/asciidoc/build.adoc
+++ b/documentation/src/main/asciidoc/build.adoc
@@ -2,8 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
 The DeltaSpike source (modules and examples) is provided for inspection, contribution and testing purposes. The source must be built with Maven, which has been used to automate the compilation, testing and packaging processes. Arquillian tests are included with the source and a CDI implementation or container can be specified with which to carry out the tests.
 
 In all cases, to obtain the DeltaSpike source, link:https://deltaspike.apache.org/download.html[download] `deltaspike-project-{latestStable}-source-release.zip` and extract the contents.

--- a/documentation/src/main/asciidoc/cdiimp.adoc
+++ b/documentation/src/main/asciidoc/cdiimp.adoc
@@ -2,8 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
 DeltaSpike requires a CDI implementation to be available in the Java environment where your projects are deployed. The implementation provides the CDI essentials, managing dependency injection and contextual lifecycles. link:http://weld.cdi-spec.org/[JBoss Weld] and link:http://openwebbeans.apache.org/[Apache OpenWebBeans (OWB)] are two widely used CDI implementations. Dependent on the Java environment you choose, some setup may be necessary as detailed here.
 
 == Java EE6+ Containers

--- a/documentation/src/main/asciidoc/configuration.adoc
+++ b/documentation/src/main/asciidoc/configuration.adoc
@@ -2,8 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
 == Configuration Basics
 
 

--- a/documentation/src/main/asciidoc/configure.adoc
+++ b/documentation/src/main/asciidoc/configure.adoc
@@ -2,9 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
-
 DeltaSpike is available for use in Maven-based and Maven-independent projects. Instructions are given here for obtaining released final versions of DeltaSpike for both approaches.
 
 NOTE: You can also opt to use the lastest DeltaSpike snapshots; for more information, see <<snapshots#,Use DeltaSpike Snapshots>>.

--- a/documentation/src/main/asciidoc/container-control.adoc
+++ b/documentation/src/main/asciidoc/container-control.adoc
@@ -2,8 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
 == Overview
 The Container Control module provides CDI container booting and shutdown, crucial for CDI use in Java SE6+ environments, and associated context lifecycle management. The module abstracts individual CDI container implementations, ensuring projects are container-independent.
 

--- a/documentation/src/main/asciidoc/core.adoc
+++ b/documentation/src/main/asciidoc/core.adoc
@@ -2,8 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
 == Overview
 The Core module provides fundamental and defining DeltaSpike API and utility classes. As such, this module must be included in every project that uses DeltaSpike.
 

--- a/documentation/src/main/asciidoc/data.adoc
+++ b/documentation/src/main/asciidoc/data.adoc
@@ -2,8 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
 == Overview
 The Data module provides capabilities for implementing repository patterns and thereby simplifying the repository layer. Repository patterns are ideal for simple queries that require boilerplate code, enabling cenertalization of query logic and consequently reducing code duplication and improving testability.
 

--- a/documentation/src/main/asciidoc/index.adoc
+++ b/documentation/src/main/asciidoc/index.adoc
@@ -24,7 +24,7 @@
 ** <<build#,Build and Test DeltaSpike from Source>>
 ** <<snapshots#,Use DeltaSpike Snapshots>>
 ** link:https://deltaspike.apache.org/migration-guide.html[Migrate to DeltaSpike]
-** <<source#,Contribute to the DeltaSpike Source>>
+** link:https://deltaspike.apache.org/source.html[Contribute to the DeltaSpike Source]
 ** <<spi#,DeltaSpike Service Provider Interface (SPI)>>
 * Access More DeltaSpike Resources
 ** link:http://deltaspike.apache.org/articles.html[Articles and Blogs]

--- a/documentation/src/main/asciidoc/jpa.adoc
+++ b/documentation/src/main/asciidoc/jpa.adoc
@@ -2,8 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
 == Overview
 The JPA module provides a transactional context and scope, enabling execution of methods within transactions.
 

--- a/documentation/src/main/asciidoc/jsf.adoc
+++ b/documentation/src/main/asciidoc/jsf.adoc
@@ -2,8 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
 == Overview
 The JSF module provides CDI integration with JSF, with type-safe view config, multi-window handling, new scopes (WindowScoped, ViewScope, ViewAccessScoped, GroupedConversationScoped) and integration with DeltaSpike “core” messages and exception handling.
 

--- a/documentation/src/main/asciidoc/modules.adoc
+++ b/documentation/src/main/asciidoc/modules.adoc
@@ -2,8 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
 DeltaSpike consists of ready-to-use modules. These include a core module and a number of optional modules for providing additional enterprise functionality to your applications. An overview of each module is provided here and for more information see the linked individual module pages.
 
 [cols="1,1,2a"]

--- a/documentation/src/main/asciidoc/overview.adoc
+++ b/documentation/src/main/asciidoc/overview.adoc
@@ -2,9 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
-
 == Background
 
 === CDI

--- a/documentation/src/main/asciidoc/partial-bean.adoc
+++ b/documentation/src/main/asciidoc/partial-bean.adoc
@@ -2,8 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
 == Overview
 The Partial-Bean module provides means for implementing a generic handler to replace manual implementations of interfaces (or abstract classes).
 

--- a/documentation/src/main/asciidoc/projectstage.adoc
+++ b/documentation/src/main/asciidoc/projectstage.adoc
@@ -2,8 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
 == Introduction
 
 Project stages allow to use implementations depending on the current

--- a/documentation/src/main/asciidoc/scheduler.adoc
+++ b/documentation/src/main/asciidoc/scheduler.adoc
@@ -2,8 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
 == Overview
 The Scheduler module provides simple integration with Quartz v2 (default) or any other scheduler that supports cron-expressions for job-classes.
 

--- a/documentation/src/main/asciidoc/security.adoc
+++ b/documentation/src/main/asciidoc/security.adoc
@@ -2,8 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
 == Overview
 The Security module provides intercept and security checking on method calls. This module also enables integration of third-party security frameworks and custom security concepts.
 

--- a/documentation/src/main/asciidoc/servlet.adoc
+++ b/documentation/src/main/asciidoc/servlet.adoc
@@ -2,8 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
 == Overview
 The Servlet module provides CDI integration with the Java Servlet API. It enables injection of common servlet objects and propagation of servlet events to the CDI event bus.
 

--- a/documentation/src/main/asciidoc/snapshots.adoc
+++ b/documentation/src/main/asciidoc/snapshots.adoc
@@ -2,8 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
 If you want to be at the bleeding edge, you can work with DeltaSpike snapshots. These are available from the Apache Snapshot Repository for use in Maven-based projects. To begin using them, you must configure Maven with the repository location and your projects with the snapshot version.
 
 WARNING: Snapshots provide previews of DeltaSpike during development. Snapshots are subject to change and may not yet include all expected features of the final release. Snapshots should not be used in production environments.

--- a/documentation/src/main/asciidoc/spi.adoc
+++ b/documentation/src/main/asciidoc/spi.adoc
@@ -2,8 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
 DeltaSpike provides an Service Provider Interface (SPI) to enable you to extend it.
 
 == Deactivatable

--- a/documentation/src/main/asciidoc/test-control.adoc
+++ b/documentation/src/main/asciidoc/test-control.adoc
@@ -2,8 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
 == Overview
 The Test-Control module enables you to write CDI-based tests easily. Calls to stop and start the CDI container are built into the Test-Control API, with simplified commands for customizing the management of contexts and other aspects during testing.
 

--- a/site/src/main/asciidoc/addons.adoc
+++ b/site/src/main/asciidoc/addons.adoc
@@ -2,8 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
 Add-ons extend the functionality of DeltaSpike and several have been developed external to the DeltaSpike project. Brief information is given here about each of the add-ons, with details of where they can be obtained from.
 
 == Monitoring

--- a/site/src/main/asciidoc/articles.adoc
+++ b/site/src/main/asciidoc/articles.adoc
@@ -2,8 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
 You can find lots of content related to DeltaSpike with a quick internet search. But here is a list of some useful articles and blogs to get you started.
 
 If you know of useful DeltaSpike articles or blogs that are not listed, link:https://deltaspike.apache.org/community.html[let us know]. 

--- a/site/src/main/asciidoc/community.adoc
+++ b/site/src/main/asciidoc/community.adoc
@@ -2,8 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
 == Introduction
 
 

--- a/site/src/main/asciidoc/documentation.adoc
+++ b/site/src/main/asciidoc/documentation.adoc
@@ -2,12 +2,9 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
-
 == Sources
 
-link:/documentation/[DeltaSpike Documentation] is available with link:documentation/source.html[DeltaSpike Source].
+link:/documentation/[DeltaSpike Documentation] is available with <<source#, DeltaSpike Source>>.
 
 == Format
 

--- a/site/src/main/asciidoc/download.adoc
+++ b/site/src/main/asciidoc/download.adoc
@@ -2,8 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
 == Latest Release
 
 

--- a/site/src/main/asciidoc/examples.adoc
+++ b/site/src/main/asciidoc/examples.adoc
@@ -2,8 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
 A collection of ready-to-build Maven-based projects are provided to demonstrate the inclusion of DeltaSpike in applications. Each example showcases a different DeltaSpike feature and explores the mechanics of DeltaSpike implementation. You can use these examples to see DeltaSpike in action and learn how to add these capabilities to your own projects. The Maven-based project examples are available in `deltaspike-project-{latestStable}-source-release.zip`.
 	
 To begin using the projects, complete the following steps:

--- a/site/src/main/asciidoc/external.adoc
+++ b/site/src/main/asciidoc/external.adoc
@@ -2,8 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
 A number of DeltaSpike examples and templates have been developed external to the DeltaSpike project. These extend the DeltaSpike resources from which you can see DeltaSpike in action. Brief information is given here about the examples and templates, with details of where they can be obtained from.
 
 == Presentations

--- a/site/src/main/asciidoc/javadoc.adoc
+++ b/site/src/main/asciidoc/javadoc.adoc
@@ -2,8 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
 == Latest version
 
 * link:/javadoc/{latestSnapshot}/[{latestSnapshot}]

--- a/site/src/main/asciidoc/migration-guide.adoc
+++ b/site/src/main/asciidoc/migration-guide.adoc
@@ -2,8 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
 
 == Introduction
 

--- a/site/src/main/asciidoc/news.adoc
+++ b/site/src/main/asciidoc/news.adoc
@@ -2,9 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
-
 == Overview
 
 === 15th Release (1.3.0) (10.03.2015)

--- a/site/src/main/asciidoc/release-preparation.adoc
+++ b/site/src/main/asciidoc/release-preparation.adoc
@@ -2,9 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
-
 == Introduction
 
 

--- a/site/src/main/asciidoc/source.adoc
+++ b/site/src/main/asciidoc/source.adoc
@@ -2,8 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
 If you are looking to contribute to the DeltaSpike source, you must start with the latest version of the code base. DeltaSpike source is stored in the Apache Git repository at https://git-wip-us.apache.org/repos/asf/deltaspike.git
 
 It is also important that you follow the git workflows we have established for the project to ensure efficient and clean collaboration as detailed here.

--- a/site/src/main/asciidoc/steps_for_a_release.adoc
+++ b/site/src/main/asciidoc/steps_for_a_release.adoc
@@ -2,8 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
 == Preparations
 
  - Heads up on the mailing-lists

--- a/site/src/main/asciidoc/suggested-git-workflows.adoc
+++ b/site/src/main/asciidoc/suggested-git-workflows.adoc
@@ -2,9 +2,6 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-:toc:
-
-
 == Avoid git-pull!
 
 git-pull should never get invoked if you have dirty files lying around

--- a/template/document.html.erb
+++ b/template/document.html.erb
@@ -35,7 +35,7 @@
 
 <link href="https://deltaspike.apache.org/resources/css/bootstrap.css" rel="stylesheet">
 <link href="https://deltaspike.apache.org/resources/css/bootstrap-responsive.css" rel="stylesheet">
-<link href="http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.1.0/css/font-awesome.min.css" rel="stylesheet" >
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.1.0/css/font-awesome.min.css" rel="stylesheet" >
 
 <style type="text/css">
 <%= ::Asciidoctor::Stylesheets.instance.coderay_stylesheet_data %>
@@ -72,20 +72,27 @@ body {
         </a>
         <a class="brand logocolor" href="<%= (attr :sitebasedir) %>/index.html">Apache DeltaSpike</a>
         <div class="nav-collapse">
+     
+          <% 
+          def active_page(page)
+            docpage = attributes.has_key?('docpage') ? attributes['docpage'] : attributes['docname']
+            'class="active"' if docpage == page
+          end
+          %>
           <ul class="nav">
-            <li class="active"><a href="<%= (attr :sitebasedir) %>/index.html">Home</a></li>
-            <li><a href="<%= (attr :sitebasedir) %>/documentation">Documentation</a></li>
-            <li><a href="<%= (attr :sitebasedir) %>/javadoc.html">Javadoc</a></li>
-            <li><a href="<%= (attr :sitebasedir) %>/documentation/source.html">Source</a></li>
-            <li><a href="<%= (attr :sitebasedir) %>/download.html">Download</a></li>
-            <li><a href="<%= (attr :sitebasedir) %>/community.html">Community</a></li>
+            <li><a href="<%= (attr :sitebasedir) %>/index.html">Home</a></li>
+            <li <%= active_page("documentation") %>><a href="<%= (attr :sitebasedir) %>/documentation">Documentation</a></li>
+            <li <%= active_page("javadoc") %> ><a href="<%= (attr :sitebasedir) %>/javadoc.html">Javadoc</a></li>
+            <li <%= active_page("source") %>><a href="<%= (attr :sitebasedir) %>/source.html">Source</a></li>
+            <li <%= active_page("download") %>><a href="<%= (attr :sitebasedir) %>/download.html">Download</a></li>
+            <li <%= active_page("community") %>><a href="<%= (attr :sitebasedir) %>/community.html">Community</a></li>
             <!-- <li><a href="./support.html">Support</a></li>  -->
-            <li><a href="<%= (attr :sitebasedir) %>/news.html">News</a></li>
-            <li><a href="<%= (attr :sitebasedir) %>/migration-guide.html">Migration</a></li>
+            <li <%= active_page("news") %>><a href="<%= (attr :sitebasedir) %>/news.html">News</a></li>
+            <li <%= active_page("migration-guide") %>><a href="<%= (attr :sitebasedir) %>/migration-guide.html">Migration</a></li>
           </ul>
         </div>
         <!--/.nav-collapse -->
-        <form id="search-form" action="http://www.google.com/search"
+        <form id="search-form" action="https://www.google.com/search"
           method="get" class="navbar-search pull-right">
           <input value="deltaspike.apache.org" name="sitesearch"
             type="hidden"> <input class="search-query" name="q"


### PR DESCRIPTION
Also, removed toc attribute from all documents, since TOC generation is handled in the template.