### PR TITLE
DELTASPIKE-594 removed static singleton RepositoryComponents

### DIFF
--- a/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/RepositoryExtension.java
+++ b/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/RepositoryExtension.java
@@ -36,7 +36,7 @@ import org.apache.deltaspike.core.spi.activation.Deactivatable;
 import org.apache.deltaspike.core.util.ClassDeactivationUtils;
 import org.apache.deltaspike.data.api.AbstractEntityRepository;
 import org.apache.deltaspike.data.api.Repository;
-import org.apache.deltaspike.data.impl.meta.RepositoryComponentsFactory;
+import org.apache.deltaspike.data.impl.meta.RepositoryComponents;
 import org.apache.deltaspike.data.impl.meta.unit.PersistenceUnits;
 
 /**
@@ -62,6 +62,9 @@ public class RepositoryExtension implements Extension, Deactivatable
             new LinkedList<RepositoryDefinitionException>();
 
     private Boolean isActivated = true;
+
+    private RepositoryComponents components = new RepositoryComponents();
+
 
     void beforeBeanDiscovery(@Observes BeforeBeanDiscovery before)
     {
@@ -100,7 +103,7 @@ public class RepositoryExtension implements Extension, Deactivatable
                     log.log(Level.FINER, "Class {0} is Deactivated", repoClass);
                     return;
                 }
-                RepositoryComponentsFactory.instance().add(repoClass);
+                components.add(repoClass);
             }
             catch (RepositoryDefinitionException e)
             {
@@ -136,6 +139,11 @@ public class RepositoryExtension implements Extension, Deactivatable
     private <X> boolean isVetoed(AnnotatedType<X> annotated)
     {
         return annotated.getJavaClass().equals(AbstractEntityRepository.class);
+    }
+    
+    public RepositoryComponents getComponents()
+    {
+        return components;
     }
 
 }

--- a/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/meta/RepositoryComponentsFactory.java
+++ b/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/meta/RepositoryComponentsFactory.java
@@ -18,29 +18,25 @@
  */
 package org.apache.deltaspike.data.impl.meta;
 
-import org.apache.deltaspike.core.api.lifecycle.Initialized;
-
 import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+import org.apache.deltaspike.core.api.lifecycle.Initialized;
+import org.apache.deltaspike.data.impl.RepositoryExtension;
 
 /**
- * Repository components producer. Exposes a singleton both programmatically as well
- * as over a CDI producer.
+ * Repository components producer.
  */
 public class RepositoryComponentsFactory
 {
 
-    private static RepositoryComponents components = new RepositoryComponents();
-
-    public static RepositoryComponents instance()
-    {
-        return components;
-    }
-
+    @Inject
+    private RepositoryExtension extension;
+    
     @Produces
     @Initialized
     public RepositoryComponents producer()
     {
-        return instance();
+        return extension.getComponents();
     }
-
 }


### PR DESCRIPTION
This is now an application-scoped bean, thus fixing a potential
classloader leak when application is undeployed.

Had to remove RepositoryComponentsFactory.instance() API, which probably shouldn't have been there in the first place. It was not used anywhere in DS.

Tested with -Pwildfly-remote.