### PR TITLE
Add ViewAccessHandler API and tests for @Secured

### DIFF
--- a/deltaspike/modules/jsf/api/src/main/java/org/apache/deltaspike/jsf/api/security/ViewAccessHandler.java
+++ b/deltaspike/modules/jsf/api/src/main/java/org/apache/deltaspike/jsf/api/security/ViewAccessHandler.java
@@ -1,0 +1,91 @@
+package org.apache.deltaspike.jsf.api.security;
+
+import javax.faces.component.UIViewRoot;
+
+import org.apache.deltaspike.core.api.config.view.ViewConfig;
+import org.apache.deltaspike.core.api.config.view.metadata.ViewConfigDescriptor;
+
+/**
+ * Allows the application to programmatically run security checks for a view.
+ */
+public interface ViewAccessHandler
+{
+
+    /**
+     * Determines if access is permitted to the view with the given ID.
+     * 
+     * @param viewId
+     *            The ID of the view to check
+     * @return True if access is permitted, false if not
+     */
+    boolean canAccessView(String viewId);
+
+    /**
+     * Determines if access is permitted to the view represented by the given
+     * {@link UIViewRoot}.
+     * 
+     * @param viewRoot
+     *            The view to check
+     * @return True if access is permitted, false if not
+     */
+    boolean canAccessView(UIViewRoot viewRoot);
+
+    /**
+     * Determines if access is permitted to the view with the given descriptor.
+     * 
+     * @param viewDescriptor
+     *            The descriptor of the view to check
+     * @return True if access is permitted, false if not
+     */
+    boolean canAccessView(ViewConfigDescriptor viewDescriptor);
+    
+    /**
+     * Determines if access is permitted to the view represented by the given {@link ViewConfig}.
+     * 
+     * @param viewConfig
+     *            The ViewConfig to check
+     * @return True if access is permitted, false if not
+     */
+    boolean canAccessView(Class<? extends ViewConfig> viewConfig);
+
+    /**
+     * Determines if access is permitted to the view with the given ID. An
+     * ErrorViewAwareAccessDeniedException will be thrown if access is not
+     * permitted.
+     * 
+     * @param viewId
+     *            The ID of the view to check
+     */
+    void checkAccessToView(String viewId);
+
+    /**
+     * Determines if access is permitted to the view represented by the given
+     * {@link UIViewRoot}. An ErrorViewAwareAccessDeniedException will be thrown
+     * if access is not permitted.
+     * 
+     * @param viewRoot
+     *            The UIViewRoot to check
+     */
+    void checkAccessToView(UIViewRoot viewRoot);
+
+    /**
+     * Determines if access is permitted to the view with the given descriptor.
+     * An ErrorViewAwareAccessDeniedException will be thrown if access is not
+     * permitted.
+     * 
+     * @param viewDescriptor
+     *            The descriptor of the view to check
+     */
+    void checkAccessToView(ViewConfigDescriptor viewDescriptor);
+    
+    /**
+     * Determines if access is permitted to the view represented by the given
+     * {@link ViewConfig}. An ErrorViewAwareAccessDeniedException will be thrown
+     * if access is not permitted.
+     * 
+     * @param viewConfig
+     *            The ViewConfig to check
+     */
+    void checkAccessToView(Class<? extends ViewConfig> viewConfig);
+
+}

--- a/deltaspike/modules/jsf/impl/src/main/java/org/apache/deltaspike/jsf/impl/listener/phase/DeltaSpikePhaseListener.java
+++ b/deltaspike/modules/jsf/impl/src/main/java/org/apache/deltaspike/jsf/impl/listener/phase/DeltaSpikePhaseListener.java
@@ -143,7 +143,7 @@ public class DeltaSpikePhaseListener implements PhaseListener, Deactivatable
 
         try
         {
-            BeanProvider.getContextualReference(ViewRootAccessHandler.class).checkAccessTo(facesContext.getViewRoot());
+            BeanProvider.getContextualReference(ViewRootAccessHandler.class).checkAccessToView(facesContext.getViewRoot());
         }
         catch (ErrorViewAwareAccessDeniedException accessDeniedException)
         {

--- a/deltaspike/modules/jsf/impl/src/main/java/org/apache/deltaspike/jsf/impl/security/SecurityAwareViewHandler.java
+++ b/deltaspike/modules/jsf/impl/src/main/java/org/apache/deltaspike/jsf/impl/security/SecurityAwareViewHandler.java
@@ -110,7 +110,7 @@ public class SecurityAwareViewHandler extends ViewHandlerWrapper implements Deac
             ViewRootAccessHandler viewRootAccessHandler =
                     BeanProvider.getContextualReference(ViewRootAccessHandler.class);
 
-            viewRootAccessHandler.checkAccessTo(result);
+            viewRootAccessHandler.checkAccessToView(result);
         }
         catch (ErrorViewAwareAccessDeniedException accessDeniedException)
         {

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/security/AlwaysDeniedVoter.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/security/AlwaysDeniedVoter.java
@@ -1,0 +1,41 @@
+package org.apache.deltaspike.test.jsf.impl.config.view.security;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.apache.deltaspike.security.api.authorization.AbstractDecisionVoter;
+import org.apache.deltaspike.security.api.authorization.AccessDecisionVoter;
+import org.apache.deltaspike.security.api.authorization.AccessDecisionVoterContext;
+import org.apache.deltaspike.security.api.authorization.SecurityViolation;
+
+@ApplicationScoped
+public class AlwaysDeniedVoter extends AbstractDecisionVoter implements AccessDecisionVoter, TestVoter
+{
+    private static final long serialVersionUID = 1L;
+    
+    private int invocations = 0;
+    
+    @Override
+    public int getInvocations()
+    {
+        return invocations;
+    }
+
+    @Override
+    public void reset()
+    {
+        invocations = 0;
+    }
+
+    @Override
+    public Set<SecurityViolation> checkPermission(AccessDecisionVoterContext accessDecisionVoterContext)
+    {
+        invocations++;
+        HashSet<SecurityViolation> violations = new HashSet<SecurityViolation>();
+        violations.add(newSecurityViolation("denied"));
+        return violations;
+    }
+
+}

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/security/AlwaysSucceedsVoter.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/security/AlwaysSucceedsVoter.java
@@ -1,0 +1,37 @@
+package org.apache.deltaspike.test.jsf.impl.config.view.security;
+
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.apache.deltaspike.security.api.authorization.AccessDecisionVoter;
+import org.apache.deltaspike.security.api.authorization.AccessDecisionVoterContext;
+import org.apache.deltaspike.security.api.authorization.SecurityViolation;
+
+@ApplicationScoped
+public class AlwaysSucceedsVoter implements AccessDecisionVoter, TestVoter
+{
+    private static final long serialVersionUID = 1L;
+
+    private int invocations = 0;
+    
+    @Override
+    public int getInvocations()
+    {
+        return invocations;
+    }
+
+    @Override
+    public void reset()
+    {
+        invocations = 0;
+    }
+    
+    @Override
+    public Set<SecurityViolation> checkPermission(AccessDecisionVoterContext accessDecisionVoterContext)
+    {
+        invocations++;
+        return null;
+    }
+
+}

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/security/DeploymentBuilder.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/security/DeploymentBuilder.java
@@ -1,0 +1,30 @@
+package org.apache.deltaspike.test.jsf.impl.config.view.security;
+
+import org.apache.deltaspike.test.jsf.impl.util.ArchiveUtils;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+class DeploymentBuilder
+{
+
+    static WebArchive createDeployment(String warName)
+    {
+        return ShrinkWrap
+                .create(WebArchive.class, warName)
+                .addPackage(SecuredViewTest.class.getPackage())
+                .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreAndJsfArchive())
+                .addAsLibraries(ArchiveUtils.getDeltaSpikeSecurityArchive())
+                .addAsWebInfResource("default/WEB-INF/web.xml", "web.xml")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsWebResource("navigation/pages/index.xhtml", "/pages/noSecurity.xhtml")
+                .addAsWebResource("navigation/pages/index.xhtml", "/pages/alwaysSucceeds.xhtml")
+                .addAsWebResource("navigation/pages/index.xhtml", "/pages/alwaysDenied.xhtml")
+                .addAsWebResource("navigation/pages/index.xhtml", "/pages/deniedFolder/inheritsDeniedFromFolder.xhtml")
+                .addAsWebResource("navigation/pages/index.xhtml", "/pages/deniedFolder/voterNotCalled.xhtml")
+                .addAsWebResource("navigation/pages/index.xhtml", "/pages/successFolder/compositionWithFolder.xhtml")
+                .addAsWebResource("navigation/pages/index.xhtml", "/pages/inheritsDeniedFromSuper.xhtml")
+                .addAsWebResource("navigation/pages/index.xhtml", "/pages/overridesSuper.xhtml");
+    }
+    
+}

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/security/Pages.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/security/Pages.java
@@ -1,0 +1,63 @@
+package org.apache.deltaspike.test.jsf.impl.config.view.security;
+
+import org.apache.deltaspike.core.api.config.view.ViewConfig;
+import org.apache.deltaspike.security.api.authorization.Secured;
+
+interface Pages extends ViewConfig
+{
+
+    class NoSecurity implements ViewConfig
+    {
+    }
+    
+    @Secured(AlwaysSucceedsVoter.class)
+    class AlwaysSucceeds implements ViewConfig
+    {
+    }
+    
+    @Secured(AlwaysDeniedVoter.class)
+    class AlwaysDenied implements ViewConfig
+    {
+    }
+    
+    @Secured(AlwaysDeniedVoter.class)
+    interface DeniedFolder
+    {
+        
+        class InheritsDeniedFromFolder implements ViewConfig
+        {
+        }
+        
+        @Secured(AlwaysSucceedsVoter.class)
+        class VoterNotCalled implements ViewConfig
+        {
+        }
+        
+    }
+    
+    @Secured(AlwaysSucceedsVoter.class)
+    interface SuccessFolder
+    {
+        
+        @Secured(AlwaysDeniedVoter.class)
+        class CompositionWithFolder implements ViewConfig
+        {
+        }
+        
+    }
+    
+    @Secured(AlwaysDeniedVoter.class)
+    interface SuperConfig extends ViewConfig
+    {
+    }
+    
+    class InheritsDeniedFromSuper implements SuperConfig
+    {
+    }
+    
+    @Secured(AlwaysSucceedsVoter.class)
+    class OverridesSuper implements SuperConfig
+    {
+    }
+    
+}

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/security/SecuredViewTest.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/security/SecuredViewTest.java
@@ -1,0 +1,61 @@
+package org.apache.deltaspike.test.jsf.impl.config.view.security;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.apache.deltaspike.test.category.WebProfileCategory;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+import junit.framework.Assert;
+
+@RunWith(Arquillian.class)
+@Category(WebProfileCategory.class)
+public class SecuredViewTest
+{
+
+    @Drone
+    private WebDriver driver;
+
+    @ArquillianResource
+    private URL contextPath;
+    
+    @Deployment(testable = false)
+    public static WebArchive deploy()
+    {
+        return DeploymentBuilder.createDeployment("secured-view-test.war");
+    }
+    
+    @Test
+    public void testNoVoters() throws MalformedURLException
+    {
+        checkAccess("pages/noSecurity.xhtml", true);
+    }
+    
+    @Test
+    public void testVotersAllowAccess() throws MalformedURLException
+    {
+        checkAccess("pages/alwaysSucceeds.xhtml", true);
+    }
+    
+    @Test
+    public void testVotersDenyAccess() throws MalformedURLException
+    {
+        checkAccess("pages/alwaysDenied.xhtml", false);
+    }
+    
+    private void checkAccess(String page, boolean expectSuccess) throws MalformedURLException
+    {
+        driver.get(new URL(contextPath, page).toString());
+        Assert.assertEquals(expectSuccess, driver.findElements(By.id("indexPage")).size() > 0);
+    }
+    
+}

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/security/TestVoter.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/security/TestVoter.java
@@ -1,0 +1,10 @@
+package org.apache.deltaspike.test.jsf.impl.config.view.security;
+
+interface TestVoter
+{
+
+    int getInvocations();
+    
+    void reset();
+    
+}

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/security/ViewAccessHandlerTest.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/security/ViewAccessHandlerTest.java
@@ -1,0 +1,174 @@
+package org.apache.deltaspike.test.jsf.impl.config.view.security;
+
+import javax.faces.component.UIViewRoot;
+import javax.inject.Inject;
+
+import org.apache.deltaspike.core.api.config.view.ViewConfig;
+import org.apache.deltaspike.core.api.config.view.metadata.ViewConfigDescriptor;
+import org.apache.deltaspike.core.api.config.view.metadata.ViewConfigResolver;
+import org.apache.deltaspike.jsf.api.security.ViewAccessHandler;
+import org.apache.deltaspike.security.api.authorization.ErrorViewAwareAccessDeniedException;
+import org.apache.deltaspike.test.category.WebProfileCategory;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+@Category(WebProfileCategory.class)
+public class ViewAccessHandlerTest
+{
+    
+    @Inject
+    private ViewConfigResolver viewConfigResolver;
+    @Inject
+    private ViewAccessHandler viewAccessHandler;
+    @Inject
+    private AlwaysDeniedVoter deniedVoter;
+    @Inject
+    private AlwaysSucceedsVoter succeedsVoter;
+    
+    @Deployment
+    public static WebArchive deploy()
+    {
+        return DeploymentBuilder.createDeployment("view-access-handler-test.war");
+    }
+    
+    @Test
+    public void testNoSecuredAnnotation()
+    {
+        testViewAccessHandlerMethods(Pages.NoSecurity.class, true, 0, 0);
+    }
+    
+    @Test
+    public void testSecuredAlwaysSucceeds()
+    {
+        testViewAccessHandlerMethods(Pages.AlwaysSucceeds.class, true, 0, 1);
+    }
+    
+    @Test
+    public void testSecuredAlwaysDenied()
+    {
+        testViewAccessHandlerMethods(Pages.AlwaysDenied.class, false, 1, 0);
+    }
+    
+    @Test
+    public void testInheritsDeniedFromFolder()
+    {
+        testViewAccessHandlerMethods(Pages.DeniedFolder.InheritsDeniedFromFolder.class, false, 1, 0);
+    }
+    
+    @Test
+    public void testCompositionWithDeniedFolder()
+    {
+        // voter on the view should not be called, since the voter on the folder will return a violation
+        testViewAccessHandlerMethods(Pages.DeniedFolder.VoterNotCalled.class, false, 1, 0);
+    }
+    
+    @Test
+    public void testCompositionWithSuccessFolder()
+    {
+        // both voters should be called, since the folder will not return a violation
+        testViewAccessHandlerMethods(Pages.SuccessFolder.CompositionWithFolder.class, false, 1, 1);
+    }
+    
+    @Test
+    public void testInheritsDeniedFromSuper()
+    {
+        testViewAccessHandlerMethods(Pages.InheritsDeniedFromSuper.class, false, 1, 0);
+    }
+    
+    @Test
+    public void testOverridesSuper()
+    {
+        testViewAccessHandlerMethods(Pages.OverridesSuper.class, true, 0, 1);
+    }
+    
+    private void testViewAccessHandlerMethods(Class<? extends ViewConfig> page, boolean expectSuccess,
+            int expectedDeniedInvocations, int expectedSuccessInvocations)
+    {
+        ViewConfigDescriptor descriptor = viewConfigResolver.getViewConfigDescriptor(page);
+        String viewId = descriptor.getViewId();
+        UIViewRoot viewRoot = new UIViewRoot();
+        viewRoot.setViewId(viewId);
+        
+        Assert.assertEquals(expectSuccess, viewAccessHandler.canAccessView(page));
+        checkInvocationCount(deniedVoter, expectedDeniedInvocations);
+        checkInvocationCount(succeedsVoter, expectedSuccessInvocations);
+        
+        Assert.assertEquals(expectSuccess, viewAccessHandler.canAccessView(descriptor));
+        checkInvocationCount(deniedVoter, expectedDeniedInvocations);
+        checkInvocationCount(succeedsVoter, expectedSuccessInvocations);
+        
+        Assert.assertEquals(expectSuccess, viewAccessHandler.canAccessView(viewId));
+        checkInvocationCount(deniedVoter, expectedDeniedInvocations);
+        checkInvocationCount(succeedsVoter, expectedSuccessInvocations);
+        
+        Assert.assertEquals(expectSuccess, viewAccessHandler.canAccessView(viewRoot));
+        checkInvocationCount(deniedVoter, expectedDeniedInvocations);
+        checkInvocationCount(succeedsVoter, expectedSuccessInvocations);
+        
+        boolean actualSuccess;
+        try
+        {
+            viewAccessHandler.checkAccessToView(page);
+            actualSuccess = true;
+        }
+        catch (ErrorViewAwareAccessDeniedException e)
+        {
+            actualSuccess = false;
+        }
+        Assert.assertEquals(expectSuccess, actualSuccess);
+        checkInvocationCount(deniedVoter, expectedDeniedInvocations);
+        checkInvocationCount(succeedsVoter, expectedSuccessInvocations);
+        
+        try
+        {
+            viewAccessHandler.checkAccessToView(descriptor);
+            actualSuccess = true;
+        }
+        catch (ErrorViewAwareAccessDeniedException e)
+        {
+            actualSuccess = false;
+        }
+        Assert.assertEquals(expectSuccess, actualSuccess);
+        checkInvocationCount(deniedVoter, expectedDeniedInvocations);
+        checkInvocationCount(succeedsVoter, expectedSuccessInvocations);
+        
+        try
+        {
+            viewAccessHandler.checkAccessToView(viewId);
+            actualSuccess = true;
+        }
+        catch (ErrorViewAwareAccessDeniedException e)
+        {
+            actualSuccess = false;
+        }
+        Assert.assertEquals(expectSuccess, actualSuccess);
+        checkInvocationCount(deniedVoter, expectedDeniedInvocations);
+        checkInvocationCount(succeedsVoter, expectedSuccessInvocations);
+        
+        try
+        {
+            viewAccessHandler.checkAccessToView(viewRoot);
+            actualSuccess = true;
+        }
+        catch (ErrorViewAwareAccessDeniedException e)
+        {
+            actualSuccess = false;
+        }
+        Assert.assertEquals(expectSuccess, actualSuccess);
+        checkInvocationCount(deniedVoter, expectedDeniedInvocations);
+        checkInvocationCount(succeedsVoter, expectedSuccessInvocations);
+    }
+    
+    private void checkInvocationCount(TestVoter voter, int expectedInvocations)
+    {
+        Assert.assertEquals(expectedInvocations, voter.getInvocations());
+        voter.reset();
+    }
+    
+}


### PR DESCRIPTION
The API allows applications to programmatically check if access is allowed. Currently you can kinda, sorta do that by injecting ViewRootAccessHandler, but that's an implementation class and its API is not ideal.

I also added tests to verify that the Secured annotations get evaluated correctly, since none existed. I did not try them with the old code, so I cannot guarantee that the behavior is 100% identical, but I tested all of the cases I could think of.