### PR TITLE
DELTASPIKE-1091 created separate profiles for Weld versions, changed…

### DIFF
--- a/deltaspike/modules/test-control/impl/pom.xml
+++ b/deltaspike/modules/test-control/impl/pom.xml
@@ -166,20 +166,16 @@
             </dependencies>
         </profile>
         <profile>
-            <id>Weld</id>
+            <id>Weld1</id>
             <dependencies>
+                <!-- Adding a test dependency needed for Weld 1.x -->
                 <dependency>
                     <groupId>org.apache.deltaspike.cdictrl</groupId>
                     <artifactId>deltaspike-cdictrl-weld</artifactId>
                     <scope>test</scope>
                 </dependency>
-
-                <dependency>
-                    <groupId>org.jboss.weld.se</groupId>
-                    <artifactId>weld-se-core</artifactId>
-                    <version>${weld.version}</version>
-                    <scope>test</scope>
-                </dependency>
+                
+                <!-- The remaining bits of this profile are located under deltaspike/parent/code/pom.xml -->
             </dependencies>
         </profile>
     </profiles>

--- a/deltaspike/parent/code/pom.xml
+++ b/deltaspike/parent/code/pom.xml
@@ -306,14 +306,172 @@
         </profile>
 
         <profile>
-            <!-- use this profile to compile and test DeltaSpike with JBoss Weld -->
-            <id>Weld</id>
+            <!-- use this profile to compile and test DeltaSpike with JBoss Weld 1.x on an embedded container-->
+            <id>Weld1</id>
 
+            <dependencyManagement>
+                <dependencies>
+                    <!-- Weld Core BOM - used to fetch version of artifacts only -->
+                    <dependency>
+                        <groupId>org.jboss.weld</groupId>
+                        <artifactId>weld-core-bom</artifactId>
+                        <version>${weld.version}</version>
+                        <type>pom</type>
+                        <scope>import</scope>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+            
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.weld</groupId>
+                    <artifactId>weld-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.weld.servlet</groupId>
+                    <artifactId>weld-servlet-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.weld.servlet</groupId>
+                    <artifactId>weld-servlet</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.weld.se</groupId>
+                    <artifactId>weld-se</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.weld.se</groupId>
+                    <artifactId>weld-se-core</artifactId>
+                </dependency>
+                <!-- needed for modules/test-control tests -->
+<!--                <dependency>
+                    <groupId>org.apache.deltaspike.cdictrl</groupId>
+                    <artifactId>deltaspike-cdictrl-weld</artifactId>
+                    <scope>test</scope>
+                </dependency>-->
+            </dependencies>
+        </profile>
+        
+        <profile>
+            <!-- use this profile to compile and test DeltaSpike with JBoss Weld 2.x on an embedded container -->
+            <id>Weld2</id>
+
+            <dependencyManagement>
+                <dependencies>
+                    <!-- Weld Core BOM - used to fetch version of artifacts only -->
+                    <dependency>
+                        <groupId>org.jboss.weld</groupId>
+                        <artifactId>weld-core-bom</artifactId>
+                        <version>${weld.version}</version>
+                        <type>pom</type>
+                        <scope>import</scope>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+            
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.weld</groupId>
+                    <artifactId>weld-core-impl</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.weld.servlet</groupId>
+                    <artifactId>weld-servlet</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.weld.servlet</groupId>
+                    <artifactId>weld-servlet-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.weld.se</groupId>
+                    <artifactId>weld-se</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.weld.se</groupId>
+                    <artifactId>weld-se-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.weld</groupId>
+                    <artifactId>weld-api</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+            
+        <profile>
+            <!-- use this profile to compile and test DeltaSpike with JBoss Weld 3.x on an embedded container -->
+            <id>Weld3</id>
+
+            <dependencyManagement>
+                <dependencies>
+                    <!-- Weld Core BOM - used to fetch version of artifacts only -->
+                    <dependency>
+                        <groupId>org.jboss.weld</groupId>
+                        <artifactId>weld-core-bom</artifactId>
+                        <version>${weld.version}</version>
+                        <type>pom</type>
+                        <scope>import</scope>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+            
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.weld</groupId>
+                    <artifactId>weld-core-impl</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.weld.module</groupId>
+                    <artifactId>weld-ejb</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.weld.module</groupId>
+                    <artifactId>weld-jsf</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.weld.module</groupId>
+                    <artifactId>weld-jta</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.weld.module</groupId>
+                    <artifactId>weld-web</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.weld.servlet</groupId>
+                    <artifactId>weld-servlet-shaded</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.weld.servlet</groupId>
+                    <artifactId>weld-servlet-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.weld.se</groupId>
+                    <artifactId>weld-se-shaded</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.weld.se</groupId>
+                    <artifactId>weld-se-core</artifactId>
+                </dependency>         
+                <dependency>
+                    <groupId>org.jboss.weld</groupId>
+                    <artifactId>weld-api</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        
+        <profile>
+            <!-- This profile is automatically activated when using -Dweld.version=...
+            and contains common dependencies (e.g. test dependencies) and build setup -->
+            <id>Weld-common-setup</id>
+            <activation>
+                <property>
+                    <name>weld.version</name>
+                </property>
+            </activation>
+            
             <properties>
                 <cdicontainer.version>weld-${weld.version}</cdicontainer.version>
             </properties>
-
-
+            
             <build>
                 <plugins>
                     <plugin>
@@ -334,86 +492,8 @@
                 </plugins>
             </build>
 
-            <dependencyManagement>
-                <dependencies><!-- org.jboss.weld -->
-                    <dependency>
-                        <groupId>org.jboss.weld</groupId>
-                        <artifactId>weld-core-bom</artifactId>
-                        <version>${weld.version}</version>
-                        <type>pom</type>
-                        <scope>import</scope>
-                    </dependency>
-                </dependencies>
-            </dependencyManagement>
             <dependencies>
-                <dependency>
-                    <!--
-                        This is a temporary workaround for WELD-1892
-                        We add a dependency on the bom directly. This is ugly but the only option right now to support Weld 1.1.x, 2.x and 3.x without
-                        requiring separate profiles.
-                    -->
-                    <groupId>org.jboss.weld</groupId>
-                    <artifactId>weld-core-bom</artifactId>
-                    <type>pom</type>
-                    <version>${weld.version}</version>
-                    <scope>test</scope>
-                    <exclusions>
-                        <!-- Common -->
-                        <exclusion>
-                            <groupId>org.jboss.weld</groupId>
-                            <artifactId>weld-core-test</artifactId>
-                        </exclusion>
-                        <exclusion>
-                            <groupId>javax.inject</groupId>
-                            <artifactId>javax.inject-tck</artifactId>
-                        </exclusion>
-                        <exclusion>
-                            <groupId>org.jboss.weld.se</groupId>
-                            <artifactId>*</artifactId>
-                        </exclusion>
-                        <exclusion>
-                            <groupId>org.jboss.weld.servlet</groupId>
-                            <artifactId>*</artifactId>
-                        </exclusion>
-                        <!-- Weld 1.x -->
-                        <exclusion>
-                            <groupId>org.jboss.weld</groupId>
-                            <artifactId>weld-porting-package</artifactId>
-                        </exclusion>
-                        <exclusion>
-                            <groupId>org.jboss.jsr299.tck</groupId>
-                            <artifactId>*</artifactId>
-                        </exclusion>
-                        <exclusion>
-                            <groupId>org.atinject</groupId>
-                            <artifactId>inject-tck</artifactId>
-                        </exclusion>
-                        <exclusion>
-                            <groupId>org.jboss</groupId>
-                            <artifactId>jboss-vfs</artifactId>
-                        </exclusion>
-                        <exclusion>
-                            <groupId>javax.faces</groupId>
-                            <artifactId>jsf-api</artifactId>
-                        </exclusion>
-                        <!-- Weld 2.x -->
-                        <exclusion>
-                            <groupId>org.jboss.weld</groupId>
-                            <artifactId>weld-core-jsf</artifactId>
-                        </exclusion>
-                        <!-- Weld 3.x -->
-                        <exclusion>
-                            <groupId>org.jboss.weld.module</groupId>
-                            <artifactId>*</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-
-                <dependency>
-                    <groupId>org.jboss.weld</groupId>
-                    <artifactId>weld-api</artifactId>
-                    <scope>provided</scope>
-                </dependency>
+                <!--Other than Weld dependencies-->
                 <dependency>
                     <groupId>javax.el</groupId>
                     <artifactId>el-api</artifactId>

--- a/documentation/src/main/asciidoc/build.adoc
+++ b/documentation/src/main/asciidoc/build.adoc
@@ -25,11 +25,25 @@ Tests can be executed with both the JBoss Weld and Apache OpenWebBeans CDI imple
 |===
 |Container |Command to Execute Arquillian Tests
 
-|JBoss Weld
+|JBoss Weld 1.x (CDI 1.0)
 |
 [source,shell]
 ----
-$ mvn clean install -PWeld
+$ mvn clean install -PWeld1 -Dweld.version=1.1.33.Final
+----
+
+|JBoss Weld 2.x (CDI 1.2)
+|
+[source,shell]
+----
+$ mvn clean install -PWeld2 -Dweld.version=2.3.4.Final
+----
+
+|JBoss Weld 3.x (CDI 2.0)
+|
+[source,shell]
+----
+$ mvn clean install -PWeld3 -Dweld.version=3.0.0.Alpha16
 ----
 
 |Apache OpenWebBeans


### PR DESCRIPTION
… docs accordingly.

I created 3 separate profiles for Weld 1/2/3 respectively.
As all three profiles have part of their build management/dependencies in common, I took those out and put them into a separate profile (`Weld-common-setup`).

`Weld-common-setup` is automatically triggered when you use `-Dweld.version=...` when executing tests (which you do like...all the time? :) ). I couldn't really come up with other solution which would allow to avoid copying this setup into all three profiles. The downside of this is that once you run the tests without `-Dweld.version`, it will not work.

Last but not least, I modified docs (`build.adoc` to be more precise) to reflect these changes.

Ideas/comments are welcome!