### PR TITLE
[DELTASPIKE-1160] Enable other Entity types as return from native repository queries

### DIFF
--- a/deltaspike/modules/data/api/src/main/java/org/apache/deltaspike/data/api/Query.java
+++ b/deltaspike/modules/data/api/src/main/java/org/apache/deltaspike/data/api/Query.java
@@ -79,11 +79,4 @@ public @interface Query
      * Exceptions thrown on non-single result queries.
      */
     SingleResultType singleResult() default SingleResultType.JPA;
-
-    /**
-     * For native queries only, whether or not this query returns the defined entity class or not.
-     * Due to type erasure from generics, we don't have runtime information about the return collection
-     */
-    boolean returnsEntity() default true;
-
 }

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/handler/EntityRepositoryHandlerTest.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/handler/EntityRepositoryHandlerTest.java
@@ -488,4 +488,26 @@ public class EntityRepositoryHandlerTest extends TransactionalTestCase
         assertEquals(name, names.get(0));
     }
 
+    @Test
+    public void should_query_by_name()
+    {
+        String name = "should_return_entity_primary_key";
+        Simple simple = testData.createSimple(name);
+
+        Simple byName = stringIdRepo.findByName(name);
+
+        assertEquals(simple, byName);
+    }
+
+    @Test
+    public void should_query_list_by_name()
+    {
+        String name = "should_return_entity_primary_key";
+        Simple simple = testData.createSimple(name);
+
+        List<Simple> byName = stringIdRepo.findByName2(name);
+
+        assertEquals(byName.size(), 1);
+        assertEquals(simple, byName.get(0));
+    }
 }

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/service/SimpleIntermediateRepository.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/service/SimpleIntermediateRepository.java
@@ -36,6 +36,6 @@ public interface SimpleIntermediateRepository extends EntityRepository<Simple, L
     })
     Simple findBy(Long id);
 
-    @Query(value = "select name from simple_table", isNative = true, returnsEntity = false)
+    @Query(value = "select name from simple_table", isNative = true)
     List<String> findAllNames();
 }

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/service/SimpleStringIdRepository.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/service/SimpleStringIdRepository.java
@@ -18,11 +18,20 @@
  */
 package org.apache.deltaspike.data.test.service;
 
+import java.util.List;
+
 import org.apache.deltaspike.data.api.EntityRepository;
+import org.apache.deltaspike.data.api.Query;
 import org.apache.deltaspike.data.api.Repository;
+import org.apache.deltaspike.data.test.domain.Simple;
 import org.apache.deltaspike.data.test.domain.SimpleStringId;
 
 @Repository
 public interface SimpleStringIdRepository extends EntityRepository<SimpleStringId, String>
 {
+    @Query("SELECT s FROM Simple s WHERE s.name = ?1")
+    Simple findByName(String name);
+
+    @Query("SELECT s FROM Simple s WHERE s.name = ?1")
+    List<Simple> findByName2(String name);
 }


### PR DESCRIPTION
At the moment native queries can only return the same entity type as of the repository.

A special flag exist on the @Query annotation to disable mapping, this enables the possibility to return unmapped types as String, Date or Integer.

This change uses the return type of the method with the @Query annotation. 
If the type is java.util.List, it uses the generic type.

It should be checked if this behaviour is correct for all JPA providers and if some special logging is needed.

This change also removes the flag from @Query, I don't know if you want to retain it for backward compatibility reasons and mark it as deprecated.