### PR TITLE
squid:S1155 - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/deltaspike/core/api/src/main/java/org/apache/deltaspike/core/api/resourceloader/ClasspathResourceProvider.java
+++ b/deltaspike/core/api/src/main/java/org/apache/deltaspike/core/api/resourceloader/ClasspathResourceProvider.java
@@ -120,7 +120,7 @@ public class ClasspathResourceProvider extends AbstractResourceProvider
 
     private String urlsToString(List<URL> urls, String name)
     {
-        if (urls.size() == 0)
+        if (urls.isEmpty())
         {
             return String.format("No resources found for '%s'",name);
         }

--- a/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/builder/result/DefaultQueryResult.java
+++ b/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/builder/result/DefaultQueryResult.java
@@ -231,7 +231,7 @@ public class DefaultQueryResult<T> implements QueryResult<T>
     public T getAnyResult()
     {
         List<T> queryResult = getResultList();
-        return queryResult.size() > 0 ? queryResult.get(0) : null;
+        return !queryResult.isEmpty() ? queryResult.get(0) : null;
     }
 
     @Override

--- a/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/builder/result/QueryProcessorFactory.java
+++ b/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/builder/result/QueryProcessorFactory.java
@@ -149,7 +149,7 @@ public final class QueryProcessorFactory
                 default:
                     @SuppressWarnings("unchecked")
                     List<Object> queryResult = query.getResultList();
-                    result = queryResult.size() > 0 ? queryResult.get(0) : null;
+                    result = !queryResult.isEmpty() ? queryResult.get(0) : null;
             }
             if (context.isOptional())
             {

--- a/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/criteria/QueryCriteria.java
+++ b/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/criteria/QueryCriteria.java
@@ -132,7 +132,7 @@ public class QueryCriteria<C, R> implements Criteria<C, R>
     public R getAnyResult()
     {
         List<R> queryResult = getResultList();
-        return queryResult.size() > 0 ? queryResult.get(0) : null;
+        return !queryResult.isEmpty() ? queryResult.get(0) : null;
     }
 
     @Override

--- a/deltaspike/modules/jpa/impl/src/main/java/org/apache/deltaspike/jpa/impl/transaction/context/TransactionBeanStorage.java
+++ b/deltaspike/modules/jpa/impl/src/main/java/org/apache/deltaspike/jpa/impl/transaction/context/TransactionBeanStorage.java
@@ -183,7 +183,7 @@ public class TransactionBeanStorage
 
         destroyBeans(currentTci.contextualInstances);
 
-        if (oldTci.size() > 0)
+        if (!oldTci.isEmpty())
         {
             currentTci = oldTci.pop();
             endTransactionScope();

--- a/deltaspike/modules/proxy/api/src/main/java/org/apache/deltaspike/proxy/api/DeltaSpikeProxyFactory.java
+++ b/deltaspike/modules/proxy/api/src/main/java/org/apache/deltaspike/proxy/api/DeltaSpikeProxyFactory.java
@@ -110,7 +110,7 @@ public abstract class DeltaSpikeProxyFactory
 
             // check if a interceptor is defined on class level. if not, skip interceptor methods
             if (interceptMethods != null
-                    && interceptMethods.size() > 0
+                    && !interceptMethods.isEmpty()
                     && !containsInterceptorBinding(beanManager, targetClass.getDeclaredAnnotations()))
             {
                 // loop every method and check if a interceptor is defined on the method -> otherwise don't overwrite

--- a/deltaspike/modules/proxy/impl-asm5/src/main/java/org/apache/deltaspike/proxy/impl/AsmProxyClassGenerator.java
+++ b/deltaspike/modules/proxy/impl-asm5/src/main/java/org/apache/deltaspike/proxy/impl/AsmProxyClassGenerator.java
@@ -337,7 +337,7 @@ public class AsmProxyClassGenerator implements ProxyClassGenerator
 
         // catch checked exceptions and rethrow it
         boolean throwableCatched = false;
-        if (exceptionsToCatch.size() > 0)
+        if (!exceptionsToCatch.isEmpty())
         {
             rethrow = mg.mark();
             mg.visitVarInsn(Opcodes.ASTORE, 1);

--- a/deltaspike/modules/proxy/impl-asm5/src/main/java/org/apache/deltaspike/proxy/impl/invocation/AbstractManualInvocationHandler.java
+++ b/deltaspike/modules/proxy/impl-asm5/src/main/java/org/apache/deltaspike/proxy/impl/invocation/AbstractManualInvocationHandler.java
@@ -38,7 +38,7 @@ public abstract class AbstractManualInvocationHandler implements InvocationHandl
 
         // check if interceptors are defined, otherwise just call the original logik
         List<Interceptor<?>> interceptors = interceptorLookup.lookup(proxy, method);
-        if (interceptors != null && interceptors.size() > 0)
+        if (interceptors != null && !interceptors.isEmpty())
         {
             try
             {

--- a/deltaspike/modules/scheduler/impl/src/main/java/org/apache/deltaspike/scheduler/impl/SchedulerExtension.java
+++ b/deltaspike/modules/scheduler/impl/src/main/java/org/apache/deltaspike/scheduler/impl/SchedulerExtension.java
@@ -221,7 +221,7 @@ public class SchedulerExtension implements Extension, Deactivatable
                 afterBeanDiscovery.addDefinitionError(t);
             }
         }
-        else if (this.foundManagedJobClasses.size() > 0)
+        else if (!this.foundManagedJobClasses.isEmpty())
         {
             LOG.warning(
                 this.foundManagedJobClasses.size() + " scheduling-jobs found, but there is no configured scheduler");

--- a/deltaspike/modules/security/impl/src/main/java/org/apache/deltaspike/security/impl/authorization/SecuredAnnotationAuthorizer.java
+++ b/deltaspike/modules/security/impl/src/main/java/org/apache/deltaspike/security/impl/authorization/SecuredAnnotationAuthorizer.java
@@ -125,7 +125,7 @@ public class SecuredAnnotationAuthorizer
 
                 violations = voter.checkPermission(voterContext);
 
-                if (violations != null && violations.size() > 0)
+                if (violations != null && !violations.isEmpty())
                 {
                     if (voterContext instanceof EditableAccessDecisionVoterContext)
                     {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
George Kankava