### PR TITLE
squid:S2131 - Primitives should not be boxed just for 'String' conversion

### DIFF
--- a/deltaspike/core/impl/src/main/java/org/apache/deltaspike/core/impl/jmx/DynamicMBeanWrapper.java
+++ b/deltaspike/core/impl/src/main/java/org/apache/deltaspike/core/impl/jmx/DynamicMBeanWrapper.java
@@ -159,7 +159,7 @@ public class DynamicMBeanWrapper extends NotificationBroadcasterSupport implemen
                     }
                     else
                     {
-                        methodName = "" + Character.toUpperCase(fieldName.charAt(0));
+                        methodName = Character.toString(Character.toUpperCase(fieldName.charAt(0)));
                     }
 
                     Method setter = null;

--- a/deltaspike/modules/jsf/impl/src/main/java/org/apache/deltaspike/jsf/impl/scope/window/strategy/AbstractClientWindowStrategy.java
+++ b/deltaspike/modules/jsf/impl/src/main/java/org/apache/deltaspike/jsf/impl/scope/window/strategy/AbstractClientWindowStrategy.java
@@ -101,12 +101,12 @@ public abstract class AbstractClientWindowStrategy implements ClientWindow
     protected String generateNewWindowId()
     {
         //X TODO proper mechanism
-        return "" + (new Random()).nextInt() % 10000;
+        return Integer.toString((new Random()).nextInt() % 10000);
     }
 
     protected String generateNewRequestToken()
     {
-        return "" + ((int) Math.floor(Math.random() * 999));
+        return Integer.toString((int) Math.floor(Math.random() * 999));
     }
     
     protected boolean isPost(FacesContext facesContext)


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2131 - Primitives should not be boxed just for 'String' conversion.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2131
Please let me know if you have any questions.
George Kankava