### PR TITLE
Fixes for Payara mnaged profile

### DIFF
--- a/deltaspike/modules/data/impl/pom.xml
+++ b/deltaspike/modules/data/impl/pom.xml
@@ -262,6 +262,19 @@
             </build>
         </profile>
         <profile>
+            <id>payara-build-managed-4</id>
+            <build>
+                <testResources>
+                    <testResource>
+                        <directory>src/test/resources</directory>
+                    </testResource>
+                    <testResource>
+                        <directory>src/test/resources-glassfish</directory>
+                    </testResource>
+                </testResources>
+            </build>
+        </profile>
+        <profile>
             <id>tomee-build-managed</id>
             <build>
                 <testResources>

--- a/deltaspike/modules/data/test-java8/pom.xml
+++ b/deltaspike/modules/data/test-java8/pom.xml
@@ -81,6 +81,15 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -214,6 +223,19 @@
         </profile>
         <profile>
             <id>glassfish-build-managed-4</id>
+            <build>
+                <testResources>
+                    <testResource>
+                        <directory>src/test/resources</directory>
+                    </testResource>
+                    <testResource>
+                        <directory>src/test/resources-glassfish</directory>
+                    </testResource>
+                </testResources>
+            </build>
+        </profile>
+        <profile>
+            <id>payara-build-managed-4</id>
             <build>
                 <testResources>
                     <testResource>

--- a/deltaspike/modules/data/test-java8/src/test/java/org/apache/deltaspike/data/test/java8/test/Java8Test.java
+++ b/deltaspike/modules/data/test-java8/src/test/java/org/apache/deltaspike/data/test/java8/test/Java8Test.java
@@ -43,6 +43,8 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
+import java.util.Collections;
+import java.util.List;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static org.apache.deltaspike.data.test.java8.util.TestDeployments.initDeployment;
@@ -156,7 +158,9 @@ public class Java8Test
         entityManager.persist(new Simple("b"));
 
         Stream<String> names = simpleRepository2.findSimpleNames();
+        final List<String> actualSorted = names.collect(toList());
+        Collections.sort(actualSorted);
 
-        Assert.assertEquals(asList("a","b"), names.collect(toList()));
+        Assert.assertEquals(asList("a","b"), actualSorted);
     }
 }


### PR DESCRIPTION
I identified 3 issues when running `mvn clean install -Ppayara-build-managed-4`:
- missing configuration for Payara in data module projects
- wrong assertion in Java8Test test (correct me if I'm wrong, but the lists should contain the same elements, but not necessarily in the same order)
- failing tests in ContainerCtrlTckTest

I'm sending PR for the 1st and 2nd issue. The 3rd issue remains - it seems that there is a problem with Jersey integration. Jersey cannot find a context for JNDI lookup, I will need to investigate further what is the reason. The following commit would fi the issue, but it effectively disables all the tests, as Payara Server 162 uses Weld 2.3.2.Final, which is out of specified range: https://github.com/apache/deltaspike/commit/8166155a3cbdd039b0a2b4bf2a95db3da008e1bf