### PR TITLE
DELTASPIKE-1185 Allow customization (name, description) of JMX managed...

### DIFF
--- a/deltaspike/core/api/src/main/java/org/apache/deltaspike/core/api/jmx/JmxParameter.java
+++ b/deltaspike/core/api/src/main/java/org/apache/deltaspike/core/api/jmx/JmxParameter.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.deltaspike.core.api.jmx;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Describes a parameter of a JMX operation.
+ */
+@Retention(RUNTIME)
+@Target(PARAMETER)
+@Documented
+public @interface JmxParameter
+{
+    /**
+     * @return the description of the parameter.
+     */
+    String description() default "";
+    
+    /**
+     * @return the name of the parameter.
+     */
+    String name() default "";
+}

--- a/deltaspike/core/api/src/main/java/org/apache/deltaspike/core/util/ParameterUtil.java
+++ b/deltaspike/core/api/src/main/java/org/apache/deltaspike/core/util/ParameterUtil.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.deltaspike.core.util;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import javax.enterprise.inject.Typed;
+
+@Typed()
+public abstract class ParameterUtil
+{
+    private static boolean parameterSupported = true;
+    private static Class<?> parameterClass;
+    private static Method getNameMethod;
+    private static Method getParametersMethod;
+
+    static
+    {
+        try
+        {
+            parameterClass = Class.forName("java.lang.reflect.Parameter");
+            getNameMethod = parameterClass.getMethod("getName");
+            getParametersMethod = Method.class.getMethod("getParameters");
+        }
+        catch (Exception e)
+        {
+            parameterSupported = false;
+            parameterClass = null;
+            getNameMethod = null;
+            getParametersMethod = null;
+        }
+    }
+
+    public static boolean isParameterSupported()
+    {
+        return parameterSupported;
+    }
+
+    public static String getName(Method method, int parameterIndex)
+    {
+        if (!isParameterSupported() || method == null)
+        {
+            return null;
+        }
+        try
+        {
+            Object[] parameters = (Object[]) getParametersMethod.invoke(method);
+            return (String) getNameMethod.invoke(parameters[parameterIndex]);
+        }
+        catch (IllegalAccessException e)
+        {
+        }
+        catch (InvocationTargetException e)
+        {
+        }
+        return null;
+    }
+}

--- a/deltaspike/core/api/src/test/java/org/apache/deltaspike/core/util/ParameterUtilTest.java
+++ b/deltaspike/core/api/src/test/java/org/apache/deltaspike/core/util/ParameterUtilTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.deltaspike.core.util;
+
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+
+public class ParameterUtilTest
+{
+    @Before
+    public void isEnabled()
+    {
+        Assume.assumeTrue(ParameterUtil.isParameterSupported());
+    }
+
+    @Test
+    public void shouldReturnNameOrNull() throws Exception
+    {
+        Method method = getClass().getDeclaredMethod("someMethod", String.class);
+        String parameterName = ParameterUtil.getName(method, 0);
+        Assert.assertTrue(parameterName.equals("arg0") || parameterName.equals("firstParameter"));
+    }
+
+    public void someMethod(String firstParameter) {}
+}

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/jmx/MyMBean.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/jmx/MyMBean.java
@@ -20,6 +20,7 @@ package org.apache.deltaspike.test.core.impl.jmx;
 
 import org.apache.deltaspike.core.api.jmx.JmxBroadcaster;
 import org.apache.deltaspike.core.api.jmx.JmxManaged;
+import org.apache.deltaspike.core.api.jmx.JmxParameter;
 import org.apache.deltaspike.core.api.jmx.MBean;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -52,7 +53,7 @@ public class MyMBean
     }
 
     @JmxManaged(description = "multiply counter")
-    public int multiply(final int n)
+    public int multiply(@JmxParameter(name = "multiplier", description = "the multiplier") final int n)
     {
         return counter * n;
     }

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/jmx/SimpleRegistrationTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/jmx/SimpleRegistrationTest.java
@@ -63,5 +63,9 @@ public abstract class SimpleRegistrationTest {
         myMBean.broadcast();
         assertEquals(1, notifications.size());
         assertEquals(10L, notifications.iterator().next().getSequenceNumber());
+        
+        MBeanParameterInfo parameterInfo = server.getMBeanInfo(on).getOperations()[0].getSignature()[0];
+        assertEquals("multiplier", parameterInfo.getName());
+        assertEquals("the multiplier", parameterInfo.getDescription());
     }
 }


### PR DESCRIPTION
Hi,

Here is a first try at implementing the customization (name + description) of JMX operations' parameters.

I didn't know if it was better to make a new `@JmxParameter` annotation or reuse the existing `@JmxManaged` (which would have needed a new `name` attribute).

I opted for the first solution but I can change it if needed. In the 2nd solution, adding a new `name` attribute to `@JmxManaged` could also allow to override the operation name.

Regards,

Xavier