### PR TITLE
DELTASPIKE-1207: fix exception handling in DynamicMBeanWrapper.invoke()

### DIFF
--- a/deltaspike/core/api/src/main/java/org/apache/deltaspike/core/api/jmx/JmxManaged.java
+++ b/deltaspike/core/api/src/main/java/org/apache/deltaspike/core/api/jmx/JmxManaged.java
@@ -28,9 +28,11 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Describes a JMX operation or attribute, when used on a method or a field, respectively.
- *
+ * <p>
  * Used on a method it describes a JMX operation with an optional description.
- *
+ * An exception thrown by the method will be wrapped in a {@link javax.management.MBeanException}
+ * unless it already is a {@code MBeanException}.
+ * <p>
  * Used on a field it describes a JMX attribute. This attribute is readable if a getter on this field is available and
  * writable if a setter is found.
  */

--- a/deltaspike/core/impl/src/main/java/org/apache/deltaspike/core/impl/jmx/DynamicMBeanWrapper.java
+++ b/deltaspike/core/impl/src/main/java/org/apache/deltaspike/core/impl/jmx/DynamicMBeanWrapper.java
@@ -402,7 +402,7 @@ public class DynamicMBeanWrapper extends NotificationBroadcasterSupport implemen
                 {
                     throw (Error) cause;
                 }
-                throw new MBeanException((Exception) e, actionName + " failed with exception");
+                throw new MBeanException(e, actionName + " failed with exception");
             }
             catch (IllegalAccessException e)
             {

--- a/deltaspike/core/impl/src/main/java/org/apache/deltaspike/core/impl/jmx/DynamicMBeanWrapper.java
+++ b/deltaspike/core/impl/src/main/java/org/apache/deltaspike/core/impl/jmx/DynamicMBeanWrapper.java
@@ -402,6 +402,10 @@ public class DynamicMBeanWrapper extends NotificationBroadcasterSupport implemen
                 {
                     throw (Error) cause;
                 }
+                if (cause instanceof MBeanException)
+                {
+                    throw (MBeanException) cause;
+                }
                 throw new MBeanException((Exception) cause, actionName + " failed with exception");
             }
             catch (IllegalAccessException e)

--- a/deltaspike/core/impl/src/main/java/org/apache/deltaspike/core/impl/jmx/DynamicMBeanWrapper.java
+++ b/deltaspike/core/impl/src/main/java/org/apache/deltaspike/core/impl/jmx/DynamicMBeanWrapper.java
@@ -402,7 +402,7 @@ public class DynamicMBeanWrapper extends NotificationBroadcasterSupport implemen
                 {
                     throw (Error) cause;
                 }
-                throw new MBeanException(e, actionName + " failed with exception");
+                throw new MBeanException((Exception) cause, actionName + " failed with exception");
             }
             catch (IllegalAccessException e)
             {

--- a/deltaspike/core/impl/src/main/java/org/apache/deltaspike/core/impl/jmx/DynamicMBeanWrapper.java
+++ b/deltaspike/core/impl/src/main/java/org/apache/deltaspike/core/impl/jmx/DynamicMBeanWrapper.java
@@ -397,21 +397,21 @@ public class DynamicMBeanWrapper extends NotificationBroadcasterSupport implemen
             }
             catch (InvocationTargetException e)
             {
-            	final Throwable cause = e.getCause();
-            	if (cause instanceof Error)
-            	{
-            		throw (Error) cause;
-            	} 
-            	throw new MBeanException((Exception) e, actionName + " failed with exception");
+                final Throwable cause = e.getCause();
+                if (cause instanceof Error)
+                {
+                    throw (Error) cause;
+                }
+                throw new MBeanException((Exception) e, actionName + " failed with exception");
             }
             catch (IllegalAccessException e)
             {
-            	throw new ReflectionException(e, actionName + " could not be invoked");
-			}
+                throw new ReflectionException(e, actionName + " could not be invoked");
+            }
             catch (IllegalArgumentException e)
             {
-				throw new ReflectionException(e, actionName + " could not be invoked");
-			}
+                throw new ReflectionException(e, actionName + " could not be invoked");
+            }
             finally
             {
                 Thread.currentThread().setContextClassLoader(oldCl);


### PR DESCRIPTION
Ok, this fix enables the transfer of a exception thrown by the MBean method to the client.
Tomorrow I'm going to update the JIRA ticket with some output examples.

Not sure about the logging removal, though. In my project we have a logging interceptor for MBeans which logs exceptions anyway so another log entry from DynamicMBeanWrapper just "pollutes" the logfile.
Exceptions aren't swallowed either, so ...