### PR TITLE
DELTASPIKE-1208: Fixed variable replacement in configured values for …

### DIFF
--- a/deltaspike/core/api/src/main/java/org/apache/deltaspike/core/api/config/ConfigResolver.java
+++ b/deltaspike/core/api/src/main/java/org/apache/deltaspike/core/api/config/ConfigResolver.java
@@ -245,7 +245,6 @@ public final class ConfigResolver
         String value = getPropertyValue(key + '.' + ps, configResolverContext);
         if (value == null)
         {
-            configResolverContext.setProjectStageAware(false);            
             value = getPropertyValue(key, configResolverContext);
         }
 

--- a/deltaspike/core/api/src/test/java/org/apache/deltaspike/test/api/config/ConfigResolverTest.java
+++ b/deltaspike/core/api/src/test/java/org/apache/deltaspike/test/api/config/ConfigResolverTest.java
@@ -197,15 +197,27 @@ public class ConfigResolverTest
     }
     
     @Test
-    public void testProjectStageAwarePropertyValueReference() {
-        final String expected = 
+    public void testProjectStageAwarePropertyValueReference_1() {
+        final String expectedFooUrl =
+                "http://bar-dev/services";
+
+        final String actualFooUrl =
+                ConfigResolver.getProjectStageAwarePropertyValue(
+                "foo.url");
+
+        Assert.assertEquals(expectedFooUrl, actualFooUrl);
+    }
+
+    @Test
+    public void testProjectStageAwarePropertyValueReference_2() {
+        final String expected =
                 "projectStageAware-exampleEntry-1-is-tomato-UnitTest";
-        
-        final String projectStageAwareExampleEntry1 = 
+
+        final String projectStageAwareExampleEntry1 =
                 ConfigResolver.getProjectStageAwarePropertyValue(
                 "deltaspike.test.exampleEntry-2", 
                 "");
-        
+
         Assert.assertEquals(expected, projectStageAwareExampleEntry1);
     }
 

--- a/deltaspike/core/api/src/test/java/org/apache/deltaspike/test/api/config/TestConfigSource.java
+++ b/deltaspike/core/api/src/test/java/org/apache/deltaspike/test/api/config/TestConfigSource.java
@@ -93,6 +93,11 @@ public class TestConfigSource implements ConfigSource
         props.put("deltaspike.test.projectstagefallback", "Value without ProjectStage");
         
         // ProjectStage aware property value with resolved reference
+        props.put("foo.url", "${bar.url}/services");
+        props.put("bar.url", "undefined");
+        props.put("bar.url.UnitTest", "http://bar-dev");
+        props.put("bar.url.Production", "http://bar-prod");
+
         props.put("deltaspike.test.exampleEntry-1", "tomato");
         props.put("deltaspike.test.exampleEntry-1.UnitTest", "tomato-UnitTest");
         props.put("deltaspike.test.exampleEntry-2", "default-exampleEntry-1-is-${deltaspike.test.exampleEntry-1}");


### PR DESCRIPTION
### deltaspike configuration issue DELTASPIKE-1208
(https://issues.apache.org/jira/browse/DELTASPIKE-1208)

This solves the issue that the "foo.bar" was not resolved correctly in the following case when using getProjectStageAwarePropertyValue.

configuration values:
```
foo.url=${bar.url}/services
bar.url=undefined
bar.url.UnitTest=http://bar-dev
bar.url.Production=http://bar-prod
```

Expected for project stage "Production"
```
http://bar-prod/services
```
when executing
```
ConfigResolver.getProjectStageAwarePropertyValue("foo.url")
```
