### PR TITLE
DELTASPIKE-1278: Added an additonal check 

### DIFF
--- a/deltaspike/core/api/src/main/java/org/apache/deltaspike/core/util/PropertyFileUtils.java
+++ b/deltaspike/core/api/src/main/java/org/apache/deltaspike/core/util/PropertyFileUtils.java
@@ -22,6 +22,7 @@ import javax.enterprise.inject.Typed;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -41,13 +42,27 @@ public abstract class PropertyFileUtils
         // prevent instantiation
     }
 
-    public static Enumeration<URL> resolvePropertyFiles(String propertyFileName) throws IOException
+    public static Enumeration<URL> resolvePropertyFiles(String propertyFileName) throws IOException, URISyntaxException
     {
         if (propertyFileName != null && (propertyFileName.contains("://") || propertyFileName.startsWith("file:")))
         {
             // the given string is actually already an URL
             Vector<URL> propertyFileUrls = new Vector<URL>();
-            propertyFileUrls.add(new URL(propertyFileName));
+            URL url = new URL(propertyFileName);
+
+            if (propertyFileName.startsWith("file:"))
+            {
+                File file = new File(url.toURI());
+                if (file.exists())
+                {
+                    propertyFileUrls.add(url);
+                }
+            }
+            else
+            {
+                propertyFileUrls.add(url);
+            }
+
             return propertyFileUrls.elements();
         }
 

--- a/deltaspike/core/api/src/test/java/org/apache/deltaspike/core/util/PropertyFileUtilsTest.java
+++ b/deltaspike/core/api/src/test/java/org/apache/deltaspike/core/util/PropertyFileUtilsTest.java
@@ -25,6 +25,7 @@ import org.junit.runners.Parameterized;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Enumeration;
@@ -77,6 +78,17 @@ public class PropertyFileUtilsTest
                                         assertFalse(result.hasMoreElements());
                                     }
                                 }
+                        },
+                new Object[] // url not existent
+                        {
+                                new Case(new File("src/test/resources/test_not_existent.properties").toURI().toURL().toExternalForm())
+                                {
+                                    @Override
+                                    public void run()
+                                    {
+                                        assertFalse(result.hasMoreElements());
+                                    }
+                                }
                         });
     }
 
@@ -88,7 +100,7 @@ public class PropertyFileUtilsTest
     }
 
     @Test
-    public void run() throws IOException
+    public void run() throws IOException, URISyntaxException
     {
         test.result = PropertyFileUtils.resolvePropertyFiles(test.file);
         test.run();

--- a/deltaspike/core/impl/src/main/java/org/apache/deltaspike/core/impl/config/EnvironmentPropertyConfigSourceProvider.java
+++ b/deltaspike/core/impl/src/main/java/org/apache/deltaspike/core/impl/config/EnvironmentPropertyConfigSourceProvider.java
@@ -19,6 +19,7 @@
 package org.apache.deltaspike.core.impl.config;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -54,6 +55,7 @@ class EnvironmentPropertyConfigSourceProvider implements ConfigSourceProvider
             while (propertyFileUrls.hasMoreElements())
             {
                 URL propertyFileUrl = propertyFileUrls.nextElement();
+
                 LOG.log(Level.INFO,
                         "Custom config found by DeltaSpike. Name: ''{0}'', URL: ''{1}''",
                         new Object[] {propertyFileName, propertyFileUrl});
@@ -63,6 +65,10 @@ class EnvironmentPropertyConfigSourceProvider implements ConfigSourceProvider
         catch (IOException ioe)
         {
             throw new IllegalStateException("problem while loading DeltaSpike property files", ioe);
+        }
+        catch (URISyntaxException ue)
+        {
+            throw new IllegalStateException("Property file URL is malformed", ue);
         }
 
     }


### PR DESCRIPTION
This PR adds an additional check to ensure that a given file url does exist. This allows the `EnvironmentPropertyConfigSourceProvider` to respect a positive optional flag. It is still to question how to handle other non `file:\\` urls. I also thought about making optional handling part of `PropertyFileUtils#loadProperties`but wasn't sure if this brings problems to other places.