### PR TITLE
DELTASPIKE-1365: Support extra JPQL comparators in method expressions

### DIFF
--- a/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/builder/QueryOperator.java
+++ b/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/builder/QueryOperator.java
@@ -28,6 +28,7 @@ public enum QueryOperator
     LessThanEquals("LessThanEquals", "{0} <= {1}"),
     GreaterThan("GreaterThan", "{0} > {1}"),
     GreaterThanEquals("GreaterThanEquals", "{0} >= {1}"),
+    NotLike("NotLike", "{0} not like {1}"),
     Like("Like", "{0} like {1}"),
     LikeIgnoreCase("LikeIgnoreCase", "upper({0}) like {1}", true),
     NotEqual("NotEqual", "{0} <> {1}"),
@@ -37,7 +38,14 @@ public enum QueryOperator
     IgnoreCase("IgnoreCase", "upper({0}) = upper({1})"),
     Between("Between", "{0} between {1} and {2}", 2),
     IsNotNull("IsNotNull", "{0} IS NOT NULL", 0),
-    IsNull("IsNull", "{0} IS NULL", 0);
+    IsNull("IsNull", "{0} IS NULL", 0),
+    NotIn("NotIn", "{0} NOT IN {1}"),
+    In("In", "{0} IN {1}"),
+    True("True", "{0} IS TRUE", 0),
+    False("False", "{0} IS FALSE", 0),
+    Containing("Containing", "{0} like CONCAT(''%'', CONCAT({1}, ''%''))"),
+    StartingWith("StartingWith", "{0} like CONCAT({1}, ''%'')"),
+    EndingWith("EndingWith", "{0} like CONCAT(''%'', {1})");
 
     private final String expression;
     private final String jpql;

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/builder/part/QueryRootTest.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/builder/part/QueryRootTest.java
@@ -18,16 +18,16 @@
  */
 package org.apache.deltaspike.data.impl.builder.part;
 
-import static org.junit.Assert.assertEquals;
-
 import org.apache.deltaspike.data.impl.builder.MethodExpressionException;
-import org.apache.deltaspike.data.impl.meta.RepositoryMethodPrefix;
 import org.apache.deltaspike.data.impl.meta.EntityMetadata;
 import org.apache.deltaspike.data.impl.meta.RepositoryMetadata;
+import org.apache.deltaspike.data.impl.meta.RepositoryMethodPrefix;
 import org.apache.deltaspike.data.test.domain.Simple;
 import org.apache.deltaspike.data.test.service.SimpleFetchRepository;
 import org.apache.deltaspike.data.test.service.SimpleRepository;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class QueryRootTest
 {
@@ -175,6 +175,358 @@ public class QueryRootTest
         final String expected =
                 "select e from Simple e " +
                         "order by e.name desc, e.id asc";
+
+        // when
+        String result = QueryRoot.create(name, repo, prefix(name)).getJpqlQuery().trim();
+
+        // then
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void should_apply_comparator_LessThan()
+    {
+        // given
+        final String name = "findByNameLessThan";
+        final String expected =
+                "select e from Simple e " +
+                        "where e.name < ?1";
+
+        // when
+        String result = QueryRoot.create(name, repo, prefix(name)).getJpqlQuery().trim();
+
+        // then
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void should_apply_comparator_LessThanEquals()
+    {
+        // given
+        final String name = "findByNameLessThanEquals";
+        final String expected =
+                "select e from Simple e " +
+                        "where e.name <= ?1";
+
+        // when
+        String result = QueryRoot.create(name, repo, prefix(name)).getJpqlQuery().trim();
+
+        // then
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void should_apply_comparator_GreaterThan()
+    {
+        // given
+        final String name = "findByNameGreaterThan";
+        final String expected =
+                "select e from Simple e " +
+                        "where e.name > ?1";
+
+        // when
+        String result = QueryRoot.create(name, repo, prefix(name)).getJpqlQuery().trim();
+
+        // then
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void should_apply_comparator_GreaterThanEquals()
+    {
+        // given
+        final String name = "findByNameGreaterThanEquals";
+        final String expected =
+                "select e from Simple e " +
+                        "where e.name >= ?1";
+
+        // when
+        String result = QueryRoot.create(name, repo, prefix(name)).getJpqlQuery().trim();
+
+        // then
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void should_apply_comparator_Like()
+    {
+        // given
+        final String name = "findByNameLike";
+        final String expected =
+                "select e from Simple e " +
+                        "where e.name like ?1";
+
+        // when
+        String result = QueryRoot.create(name, repo, prefix(name)).getJpqlQuery().trim();
+
+        // then
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void should_apply_comparator_NotLike()
+    {
+        // given
+        final String name = "findByNameNotLike";
+        final String expected =
+                "select e from Simple e " +
+                        "where e.name not like ?1";
+
+        // when
+        String result = QueryRoot.create(name, repo, prefix(name)).getJpqlQuery().trim();
+
+        // then
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void should_apply_comparator_LikeIgnoreCase()
+    {
+        // given
+        final String name = "findByNameLikeIgnoreCase";
+        final String expected =
+                "select e from Simple e " +
+                        "where upper(e.name) like ?1";
+
+        // when
+        String result = QueryRoot.create(name, repo, prefix(name)).getJpqlQuery().trim();
+
+        // then
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void should_apply_comparator_NotEqual()
+    {
+        // given
+        final String name = "findByNameNotEqual";
+        final String expected =
+                "select e from Simple e " +
+                        "where e.name <> ?1";
+
+        // when
+        String result = QueryRoot.create(name, repo, prefix(name)).getJpqlQuery().trim();
+
+        // then
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void should_apply_comparator_NotEqualIgnoreCase()
+    {
+        // given
+        final String name = "findByNameNotEqualIgnoreCase";
+        final String expected =
+                "select e from Simple e " +
+                        "where upper(e.name) <> upper(?1)";
+
+        // when
+        String result = QueryRoot.create(name, repo, prefix(name)).getJpqlQuery().trim();
+
+        // then
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void should_apply_comparator_Equal()
+    {
+        // given
+        final String name = "findByNameEqual";
+        final String expected =
+                "select e from Simple e " +
+                        "where e.name = ?1";
+
+        // when
+        String result = QueryRoot.create(name, repo, prefix(name)).getJpqlQuery().trim();
+
+        // then
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void should_apply_comparator_EqualIgnoreCase()
+    {
+        // given
+        final String name = "findByNameEqualIgnoreCase";
+        final String expected =
+                "select e from Simple e " +
+                        "where upper(e.name) = upper(?1)";
+
+        // when
+        String result = QueryRoot.create(name, repo, prefix(name)).getJpqlQuery().trim();
+
+        // then
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void should_apply_comparator_IgnoreCase()
+    {
+        // given
+        final String name = "findByNameIgnoreCase";
+        final String expected =
+                "select e from Simple e " +
+                        "where upper(e.name) = upper(?1)";
+
+        // when
+        String result = QueryRoot.create(name, repo, prefix(name)).getJpqlQuery().trim();
+
+        // then
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void should_apply_comparator_In()
+    {
+        // given
+        final String name = "findByNameIn";
+        final String expected =
+                "select e from Simple e " +
+                        "where e.name IN ?1";
+
+        // when
+        String result = QueryRoot.create(name, repo, prefix(name)).getJpqlQuery().trim();
+
+        // then
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void should_apply_comparator_Between()
+    {
+        // given
+        final String name = "findByNameBetween";
+        final String expected =
+                "select e from Simple e " +
+                        "where e.name between ?1 and ?2";
+
+        // when
+        String result = QueryRoot.create(name, repo, prefix(name)).getJpqlQuery().trim();
+
+        // then
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void should_apply_comparator_IsNotNull()
+    {
+        // given
+        final String name = "findByNameIsNotNull";
+        final String expected =
+                "select e from Simple e " +
+                        "where e.name IS NOT NULL";
+
+        // when
+        String result = QueryRoot.create(name, repo, prefix(name)).getJpqlQuery().trim();
+
+        // then
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void should_apply_comparator_IsNull()
+    {
+        // given
+        final String name = "findByNameIsNull";
+        final String expected =
+                "select e from Simple e " +
+                        "where e.name IS NULL";
+
+        // when
+        String result = QueryRoot.create(name, repo, prefix(name)).getJpqlQuery().trim();
+
+        // then
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void should_apply_comparator_NotIn()
+    {
+        // given
+        final String name = "findByNameNotIn";
+        final String expected =
+                "select e from Simple e " +
+                        "where e.name NOT IN ?1";
+
+        // when
+        String result = QueryRoot.create(name, repo, prefix(name)).getJpqlQuery().trim();
+
+        // then
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void should_apply_comparator_True()
+    {
+        // given
+        final String name = "findByNameTrue";
+        final String expected =
+                "select e from Simple e " +
+                        "where e.name IS TRUE";
+
+        // when
+        String result = QueryRoot.create(name, repo, prefix(name)).getJpqlQuery().trim();
+
+        // then
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void should_apply_comparator_False()
+    {
+        // given
+        final String name = "findByNameFalse";
+        final String expected =
+                "select e from Simple e " +
+                        "where e.name IS FALSE";
+
+        // when
+        String result = QueryRoot.create(name, repo, prefix(name)).getJpqlQuery().trim();
+
+        // then
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void should_apply_comparator_Containing()
+    {
+        // given
+        final String name = "findByNameContaining";
+        final String expected =
+                "select e from Simple e " +
+                        "where e.name like CONCAT('%', CONCAT(?1, '%'))";
+
+        // when
+        String result = QueryRoot.create(name, repo, prefix(name)).getJpqlQuery().trim();
+
+        // then
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void should_apply_comparator_StartingWith()
+    {
+        // given
+        final String name = "findByNameStartingWith";
+        final String expected =
+                "select e from Simple e " +
+                        "where e.name like CONCAT(?1, '%')";
+
+        // when
+        String result = QueryRoot.create(name, repo, prefix(name)).getJpqlQuery().trim();
+
+        // then
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void should_apply_comparator_EndingWith()
+    {
+        // given
+        final String name = "findByNameEndingWith";
+        final String expected =
+                "select e from Simple e " +
+                        "where e.name like CONCAT('%', ?1)";
 
         // when
         String result = QueryRoot.create(name, repo, prefix(name)).getJpqlQuery().trim();

--- a/documentation/src/main/asciidoc/data.adoc
+++ b/documentation/src/main/asciidoc/data.adoc
@@ -494,18 +494,32 @@ expressions:
 
 [options="header, autowidth"]
 |===
-| Name              |# of Arguments     |Description
-| Equal             |1 | Property must be equal to argument value. If the operator is omitted in the expression, this is assumed as default.
-| NotEqual          |1 | Property must be not equal to argument value.
-| Like              |1 | Property must be like the argument value. Use the %-wildcard in the argument.
-| GreaterThan       |1 | Property must be greater than argument value.
-| GreaterThanEquals |1 | Property must be greater than or equal to argument value.
-| LessThan          |1 | Property must be less than argument value.
-| LessThanEquals    |1 | Property must be less than or equal to argument value.
-| Between           |2 | Property must be between the two argument values.
-| IsNull            |0 | Property must be null.
-| IsNotNull         |0 | Property must be non-null.
+| Name                |# of Arguments     |Description
+| Equal               |1 | Property must be equal to argument value. If the operator is omitted in the expression, this is assumed as default.
+| EqualIgnoreCase     |1 | Property must be equal to argument value (case insensitive).
+| IgnoreCase          |1 | Property must be equal to argument value (case insensitive).
+| NotEqual            |1 | Property must be not equal to argument value.
+| NotEqualIgnoreCase  |1 | Property must be not equal to argument value (case insensitive).
+| Like                |1 | Property must be like the argument value. Use the %-wildcard in the argument.
+| LikeIgnoreCase      |1 | Property must be like the argument value (case insensitive). Use the %-wildcard in the argument.
+| NotLike `*`         |1 | Property must be not like the argument value. Use the %-wildcard in the argument.
+| GreaterThan         |1 | Property must be greater than argument value.
+| GreaterThanEquals   |1 | Property must be greater than or equal to argument value.
+| LessThan            |1 | Property must be less than argument value.
+| LessThanEquals      |1 | Property must be less than or equal to argument value.
+| Between             |2 | Property must be between the two argument values.
+| IsNull              |0 | Property must be null.
+| IsNotNull           |0 | Property must be non-null.
+| In `*`              |1 | Property must be in the list of values given as a single argument. The argument should be of Collection type (e.g. List, Set, etc.).
+| NotIn `*`           |1 | Property must be not in the list of values given as a single argument. The argument should be of Collection type (e.g. List, Set, etc.).
+| True  `*`           |0 | Property must be true.
+| False `*`           |0 | Property must be false.
+| Containing `*`      |1 | Property must be like the argument value. Don't use the %-wildcard in the argument. The argument value would be automatically wrapped in a pair of %-wildcard.
+| StartingWith `*`    |1 | Property must begin with the argument value. Don't use the %-wildcard in the argument. A %-wildcard would be added automatically to the end of the argument value.
+| EndingWith `*`      |1 | Property must end with the argument value. Don't use the %-wildcard in the argument. A %-wildcard would be added automatically to the start of the argument value.
 |===
+
+`*` Comparator available since 1.9.1
 
 Note that DeltaSpike will validate those expressions during startup, so
 you will notice early in case you have a typo in those expressions.


### PR DESCRIPTION
Here is the implementation of [Support extra JPQL comparators in method expressions](https://issues.apache.org/jira/browse/DELTASPIKE-1365)
Following comparators are added:

- NotLike
- IsNull
- NotIn
- In
- True
- False
- Containing
- StartingWith
- EndingWith