### PR TITLE
DELTASPIKE-1372 Fix test-control's dependencies.

### DIFF
--- a/deltaspike/modules/test-control/impl/pom.xml
+++ b/deltaspike/modules/test-control/impl/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.apache.deltaspike.core</groupId>
             <artifactId>deltaspike-core-impl</artifactId>
-            <scope>test</scope>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Test-Control module has a de-facto runtime dependency on core-impl, which
is neither documented, nor declared in the pom. This commit adds it so
Test-Control works as described in the documentation.