### PR TITLE
DELTASPIKE-1382: Use window.location.replace() for WindowId redirect.

### DIFF
--- a/deltaspike/modules/jsf/impl/src/main/resources/static/windowhandler.html
+++ b/deltaspike/modules/jsf/impl/src/main/resources/static/windowhandler.html
@@ -181,7 +181,7 @@
 
                 dswh.utils.log('redirect to ' + redirectUrl);
 
-                window.location = redirectUrl;
+                window.location.replace(redirectUrl);
             };
             //]]>
         </script>


### PR DESCRIPTION
While assigning window.location directly seems to work well in most of the
cases, it manages to break Browser's back button if certain plugins are
installed.

See https://issues.apache.org/jira/browse/DELTASPIKE-1382 for further details.