### PR TITLE
Implement @CreatedBy, similar to @CreatedOn

### DIFF
--- a/deltaspike/modules/data/api/src/main/java/org/apache/deltaspike/data/api/audit/CreatedBy.java
+++ b/deltaspike/modules/data/api/src/main/java/org/apache/deltaspike/data/api/audit/CreatedBy.java
@@ -24,13 +24,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a property which should keep track on the last changing user.
- * By setting {@link #onCreate()} to {@code false}, the property gets NOT set when
- * the entity is persisted.
+ * Marks a property which should be updated with the current when the entity gets persisted.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.FIELD, ElementType.METHOD })
-public @interface ModifiedBy
+public @interface CreatedBy
 {
-    boolean onCreate() default true;
 }

--- a/deltaspike/modules/data/api/src/main/java/org/apache/deltaspike/data/api/audit/ModifiedOn.java
+++ b/deltaspike/modules/data/api/src/main/java/org/apache/deltaspike/data/api/audit/ModifiedOn.java
@@ -32,5 +32,10 @@ import java.lang.annotation.Target;
 @Target({ ElementType.FIELD, ElementType.METHOD })
 public @interface ModifiedOn
 {
+    /**
+     * Tells whether or not the property shall be set when the entity is first persisted.
+     * @deprecated If the property shall be set when the entity is first persisted, use {@link CreatedOn}.
+     * @return set this to {@code true} if the property shall be set when the entity is first persisted.
+     */
     boolean onCreate() default false;
 }

--- a/deltaspike/modules/data/api/src/main/java/org/apache/deltaspike/data/api/audit/ModifiedOn.java
+++ b/deltaspike/modules/data/api/src/main/java/org/apache/deltaspike/data/api/audit/ModifiedOn.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
 
 /**
  * Marks a property which should be updated with a timestamp when the entity gets updated.
- * By settings {@link #onCreate()} to {@code true}, the property gets also set when
+ * By setting {@link #onCreate()} to {@code true}, the property gets also set when
  * the entity is persisted.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/audit/AuditProvider.java
+++ b/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/audit/AuditProvider.java
@@ -18,9 +18,15 @@
  */
 package org.apache.deltaspike.data.impl.audit;
 
+import java.lang.annotation.Annotation;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.logging.Logger;
 
 import org.apache.deltaspike.data.impl.property.Property;
+import org.apache.deltaspike.data.impl.property.query.AnnotatedPropertyCriteria;
+import org.apache.deltaspike.data.impl.property.query.PropertyQueries;
+import org.apache.deltaspike.data.impl.property.query.PropertyQuery;
 
 abstract class AuditProvider implements PrePersistAuditListener, PreUpdateAuditListener
 {
@@ -32,4 +38,22 @@ abstract class AuditProvider implements PrePersistAuditListener, PreUpdateAuditL
         return entity.getClass().getSimpleName() + "." + property.getName();
     }
 
+    List<Property<Object>> getProperties(
+            Object entity,
+            Class<? extends Annotation> createdAnnotation,
+            Class<? extends Annotation> modifiedAnnotation,
+            boolean create)
+    {
+        List<Property<Object>> properties = new LinkedList<>();
+        PropertyQuery<Object> query = PropertyQueries.createQuery(entity.getClass())
+                .addCriteria(new AnnotatedPropertyCriteria(modifiedAnnotation));
+        properties.addAll(query.getWritableResultList());
+        if (create)
+        {
+            query = PropertyQueries.<Object> createQuery(entity.getClass())
+                    .addCriteria(new AnnotatedPropertyCriteria(createdAnnotation));
+            properties.addAll(query.getWritableResultList());
+        }
+        return properties;
+    }
 }

--- a/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/audit/PrincipalProvider.java
+++ b/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/audit/PrincipalProvider.java
@@ -89,7 +89,7 @@ class PrincipalProvider extends AuditProvider
         return true;
     }
 
-    private Object resolvePrincipal(Object entity, Property<Object> property)
+    protected Object resolvePrincipal(Object entity, Property<Object> property)
     {
         CurrentUser principal = AnnotationInstanceProvider.of(CurrentUser.class);
         Class<?> propertyClass = property.getJavaClass();

--- a/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/audit/TimestampsProvider.java
+++ b/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/audit/TimestampsProvider.java
@@ -20,16 +20,11 @@ package org.apache.deltaspike.data.impl.audit;
 
 import java.util.Calendar;
 import java.util.Date;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.logging.Level;
 
 import org.apache.deltaspike.data.api.audit.CreatedOn;
 import org.apache.deltaspike.data.api.audit.ModifiedOn;
 import org.apache.deltaspike.data.impl.property.Property;
-import org.apache.deltaspike.data.impl.property.query.AnnotatedPropertyCriteria;
-import org.apache.deltaspike.data.impl.property.query.PropertyQueries;
-import org.apache.deltaspike.data.impl.property.query.PropertyQuery;
 
 /**
  * Set timestamps on marked properties.
@@ -52,17 +47,7 @@ class TimestampsProvider extends AuditProvider
     private void updateTimestamps(Object entity, boolean create)
     {
         long systime = System.currentTimeMillis();
-        List<Property<Object>> properties = new LinkedList<Property<Object>>();
-        PropertyQuery<Object> query = PropertyQueries.<Object> createQuery(entity.getClass())
-                .addCriteria(new AnnotatedPropertyCriteria(ModifiedOn.class));
-        properties.addAll(query.getWritableResultList());
-        if (create)
-        {
-            query = PropertyQueries.<Object> createQuery(entity.getClass())
-                    .addCriteria(new AnnotatedPropertyCriteria(CreatedOn.class));
-            properties.addAll(query.getWritableResultList());
-        }
-        for (Property<Object> property : properties)
+        for (Property<Object> property : getProperties(entity, CreatedOn.class, ModifiedOn.class, create))
         {
             setProperty(entity, property, systime, create);
         }

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/audit/AuditEntityListenerTest.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/audit/AuditEntityListenerTest.java
@@ -110,9 +110,12 @@ public class AuditEntityListenerTest extends TransactionalTestCase
     {
         // given
         AuditedEntity entity = new AuditedEntity();
+        getEntityManager().persist(entity);
+        getEntityManager().flush();
 
         // when
-        getEntityManager().persist(entity);
+        entity = getEntityManager().find(AuditedEntity.class, entity.getId());
+        entity.setName("test");
         getEntityManager().flush();
 
         // then
@@ -120,6 +123,10 @@ public class AuditEntityListenerTest extends TransactionalTestCase
         assertEquals(who, entity.getChanger());
         assertNotNull(entity.getPrincipal());
         assertEquals(who, entity.getPrincipal().getName());
+        assertNotNull(entity.getChangerOnly());
+        assertEquals(who, entity.getChangerOnly());
+        assertNotNull(entity.getChangerOnlyPrincipal());
+        assertEquals(who, entity.getChangerOnlyPrincipal().getName());
     }
 
 }

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/audit/AuditEntityListenerTest.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/audit/AuditEntityListenerTest.java
@@ -21,6 +21,7 @@ package org.apache.deltaspike.data.impl.audit;
 import static org.apache.deltaspike.data.test.util.TestDeployments.initDeployment;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import javax.enterprise.inject.Produces;
 
@@ -129,4 +130,26 @@ public class AuditEntityListenerTest extends TransactionalTestCase
         assertEquals(who, entity.getChangerOnlyPrincipal().getName());
     }
 
+    @Test
+    public void should_set_creating_principal()
+    {
+        // given
+        AuditedEntity entity = new AuditedEntity();
+
+        // when
+        getEntityManager().persist(entity);
+        getEntityManager().flush();
+
+        // then
+        assertNotNull(entity.getCreator());
+        assertEquals(who, entity.getCreator());
+        assertNotNull(entity.getCreatorPrincipal());
+        assertEquals(who, entity.getCreatorPrincipal().getName());
+        assertNotNull(entity.getChanger());
+        assertEquals(who, entity.getChanger());
+        assertNotNull(entity.getPrincipal());
+        assertEquals(who, entity.getPrincipal().getName());
+        assertNull(entity.getChangerOnly());
+        assertNull(entity.getChangerOnlyPrincipal());
+    }
 }

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/audit/PrincipalProviderTest.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/audit/PrincipalProviderTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.deltaspike.data.impl.audit;
+
+import org.apache.deltaspike.data.api.audit.CreatedBy;
+import org.apache.deltaspike.data.impl.property.Property;
+import org.apache.deltaspike.data.test.domain.AuditedEntity;
+import org.apache.deltaspike.data.test.domain.Principal;
+import org.apache.deltaspike.data.test.domain.Simple;
+import org.junit.Test;
+
+import java.util.Date;
+
+import static org.junit.Assert.*;
+
+public class PrincipalProviderTest {
+
+    public static class MockPrincipalProvider extends PrincipalProvider {
+        private final String who;
+
+        MockPrincipalProvider(String who) {
+            this.who = who;
+        }
+
+        @Override
+        protected Object resolvePrincipal(Object entity, Property<Object> property)
+        {
+            if (property.getJavaClass().isAssignableFrom(Principal.class))
+            {
+                return new Principal(who);
+            }
+            return who;
+        }
+    }
+
+    @Test
+    public void should_set_users_for_creation()
+    {
+        // given
+        String creator = "creator";
+        MockPrincipalProvider provider = new MockPrincipalProvider(creator);
+        AuditedEntity entity = new AuditedEntity();
+
+        // when
+        provider.prePersist(entity);
+
+        // then
+        assertNotNull(entity.getCreator());
+        assertNotNull(entity.getCreatorPrincipal());
+        assertNotNull(entity.getChanger());
+        assertEquals(entity.getCreator(), creator);
+        assertEquals(entity.getCreatorPrincipal().getName(), creator);
+        assertEquals(entity.getChanger(), creator);
+        assertNull(entity.getChangerOnly());
+        assertNull(entity.getChangerOnlyPrincipal());
+    }
+
+    @Test
+    public void should_set_users_for_update()
+    {
+        // given
+        String changer = "changer";
+        MockPrincipalProvider provider = new MockPrincipalProvider(changer);
+        AuditedEntity entity = new AuditedEntity();
+
+        // when
+        provider.preUpdate(entity);
+
+        // then
+        assertNotNull(entity.getChanger());
+        assertNotNull(entity.getChangerOnly());
+        assertNotNull(entity.getChangerOnlyPrincipal());
+        assertEquals(entity.getChanger(), changer);
+        assertEquals(entity.getChangerOnly(), changer);
+        assertEquals(entity.getChangerOnlyPrincipal().getName(), changer);
+        assertNull(entity.getCreator());
+        assertNull(entity.getCreatorPrincipal());
+    }
+
+    @Test
+    public void should_not_fail_on_non_audited_entity()
+    {
+        // given
+        Simple entity = new Simple("should_not_fail_on_non_audited_entity");
+
+        // when
+        PrincipalProvider provider = new MockPrincipalProvider("");
+        provider.prePersist(entity);
+        provider.preUpdate(entity);
+
+        // then finish the test
+    }
+
+    @Test(expected = AuditPropertyException.class)
+    public void should_fail_on_invalid_entity()
+    {
+        // given
+        PrincipalProviderTest.InvalidEntity entity = new PrincipalProviderTest.InvalidEntity();
+
+        // when
+        new MockPrincipalProvider("").prePersist(entity);
+
+        // then
+        fail();
+    }
+
+    private static class InvalidEntity
+    {
+        @CreatedBy
+        private Date nonUser;
+    }
+}

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/domain/AuditedEntity.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/domain/AuditedEntity.java
@@ -31,6 +31,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 
+import org.apache.deltaspike.data.api.audit.CreatedBy;
 import org.apache.deltaspike.data.api.audit.CreatedOn;
 import org.apache.deltaspike.data.api.audit.ModifiedBy;
 import org.apache.deltaspike.data.api.audit.ModifiedOn;
@@ -49,6 +50,13 @@ public class AuditedEntity implements Serializable
     private Calendar created;
 
     private String name;
+
+    @CreatedBy
+    private String creator;
+
+    @CreatedBy
+    @ManyToOne(targetEntity = Principal.class, cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    private Principal creatorPrincipal;
 
     @ModifiedBy
     private String changer;
@@ -132,6 +140,14 @@ public class AuditedEntity implements Serializable
     public Principal getPrincipal()
     {
         return principal;
+    }
+
+    public String getCreator() {
+        return creator;
+    }
+
+    public Principal getCreatorPrincipal() {
+        return creatorPrincipal;
     }
 
     public String getChangerOnly() {

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/domain/AuditedEntity.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/domain/AuditedEntity.java
@@ -57,6 +57,13 @@ public class AuditedEntity implements Serializable
     @ManyToOne(targetEntity = Principal.class, cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     private Principal principal;
 
+    @ModifiedBy(onCreate = false)
+    private String changerOnly;
+
+    @ModifiedBy(onCreate = false)
+    @ManyToOne(targetEntity = Principal.class, cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    private Principal changerOnlyPrincipal;
+
     @Temporal(TemporalType.TIME)
     @ModifiedOn(onCreate = true)
     private java.util.Date modified;
@@ -125,5 +132,13 @@ public class AuditedEntity implements Serializable
     public Principal getPrincipal()
     {
         return principal;
+    }
+
+    public String getChangerOnly() {
+        return changerOnly;
+    }
+
+    public Principal getChangerOnlyPrincipal() {
+        return changerOnlyPrincipal;
     }
 }


### PR DESCRIPTION
As discussed on the mailing list, there are currently `@CreatedOn` and `@ModifiedOn`, but only `@ModifiedBy` and no `@CreatedBy`.

This pull-request adds `@CreatedBy` and adds a `onCreate` flag to `@ModifiedBy`. This flag - differently from `@ModifiedOn` defaults to `true` to preserve backwards compatibility. @tandraschko proposed to remove the `onCreate` flags entirely for the DeltaSpike 2 release. Hence, I marked the `onCreate` flag in `@ModifiedOn` as `@Deprecated`. I'm not sure whether I should do the same on `onCreate` flag in `@ModifiedBy`, as changing that to `false` would represent the potential future default behavior.