### PR TITLE
DELTASPIKE-1403 - fix version to 1.9.3

### DIFF
--- a/site/src/main/asciidoc/index.adoc
+++ b/site/src/main/asciidoc/index.adoc
@@ -36,7 +36,7 @@ link:/documentation/modules.html[View details »]
 [options="header,footer"]
 |===
 |*News* | *Examples*
-| Apache DeltaSpike 1.9.1 is now out!
+| Apache DeltaSpike 1.9.3 is now out!
 
 link:/news.html[View details »]
 

--- a/site/src/main/asciidoc/news.adoc
+++ b/site/src/main/asciidoc/news.adoc
@@ -4,6 +4,16 @@
 
 :Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
+== 35th Release (1.9.3) (2020-01-27)
+
+The Apache DeltaSpike team is pleased to announce the 35th release
+(v1.9.3).  Release notes can be found https://s.apache.org/DeltaSpike1.9.3[here]
+
+== 34th Release (1.9.2) (2019-12-13)
+
+The Apache DeltaSpike team is pleased to announce the 34th release
+(v1.9.2).  Release notes can be found https://s.apache.org/DeltaSpike1.9.2[here]
+
 == 33th Release (1.9.1) (2019-08-19)
 
 The Apache DeltaSpike team is pleased to announce the 33th release


### PR DESCRIPTION
1 - In main page still has 1.8.1 (https://deltaspike.apache.org/)

2 - In Dowload page too (https://deltaspike.apache.org/download.html)

[Jira - DELTASPIKE-1403](https://issues.apache.org/jira/browse/DELTASPIKE-1403)