### PR TITLE
Corrected Typo in EntityManagerFactoryProducer and Corrected Logger Strings

### DIFF
--- a/deltaspike/core/impl/src/main/java/org/apache/deltaspike/core/impl/exception/control/HandlerMethodStorageImpl.java
+++ b/deltaspike/core/impl/src/main/java/org/apache/deltaspike/core/impl/exception/control/HandlerMethodStorageImpl.java
@@ -44,7 +44,7 @@ class HandlerMethodStorageImpl implements HandlerMethodStorage
 {
     private final Map<Type, Collection<HandlerMethod<? extends Throwable>>> allHandlers;
 
-    private Logger log = Logger.getLogger(HandlerMethodStorageImpl.class.toString());
+    private Logger log = Logger.getLogger(HandlerMethodStorageImpl.class.getName());
 
     HandlerMethodStorageImpl(Map<Type, Collection<HandlerMethod<? extends Throwable>>> allHandlers)
     {

--- a/deltaspike/modules/bean-validation/impl/src/main/java/org/apache/deltaspike/beanvalidation/impl/CDIAwareConstraintValidatorFactory.java
+++ b/deltaspike/modules/bean-validation/impl/src/main/java/org/apache/deltaspike/beanvalidation/impl/CDIAwareConstraintValidatorFactory.java
@@ -31,7 +31,7 @@ import org.apache.deltaspike.core.util.ReflectionUtils;
 
 /**
  * A factory for creating CDI Aware/Enabled ConstraintValidators.
- * 
+ *
  */
 public class CDIAwareConstraintValidatorFactory implements
         ConstraintValidatorFactory
@@ -40,9 +40,8 @@ public class CDIAwareConstraintValidatorFactory implements
     private static volatile Boolean releaseInstanceMethodFound;
     private static Method releaseInstanceMethod;
 
-    private final Logger log = Logger
-            .getLogger(CDIAwareConstraintValidatorFactory.class.toString());
-    
+    private final Logger log = Logger.getLogger(CDIAwareConstraintValidatorFactory.class.getName());
+
     private final ConstraintValidatorFactory delegate;
 
     public CDIAwareConstraintValidatorFactory()
@@ -50,7 +49,7 @@ public class CDIAwareConstraintValidatorFactory implements
         delegate = Validation.byDefaultProvider().configure().getDefaultConstraintValidatorFactory();
         if (log.isLoggable(Level.CONFIG))
         {
-            log.config("Setting up delegate ConstraintValidatorFactory as " + 
+            log.config("Setting up delegate ConstraintValidatorFactory as " +
                     delegate.getClass().getCanonicalName());
         }
     }

--- a/deltaspike/modules/jpa/impl/src/main/java/org/apache/deltaspike/jpa/impl/entitymanager/EntityManagerFactoryProducer.java
+++ b/deltaspike/modules/jpa/impl/src/main/java/org/apache/deltaspike/jpa/impl/entitymanager/EntityManagerFactoryProducer.java
@@ -77,7 +77,7 @@ public class EntityManagerFactoryProducer
 
         if (unitNameAnnotation == null)
         {
-            LOG.warning("@PersisteneUnitName annotation could not be found at EntityManagerFactory injection point!");
+            LOG.warning("@PersistenceUnitName annotation could not be found at EntityManagerFactory injection point!");
 
             return null;
         }


### PR DESCRIPTION
Literally just adds one character; I was taking a peek through the `EntityManagerFactory` and related code and noticed a typo.

