### PR TITLE
Added Support for YAML Configuration

### DIFF
--- a/deltaspike/checkstyle-rules/pom.xml
+++ b/deltaspike/checkstyle-rules/pom.xml
@@ -53,4 +53,3 @@
     <name>Apache DeltaSpike CheckStyle-rules</name>
 
 </project>
-

--- a/deltaspike/core/api/src/main/java/org/apache/deltaspike/core/util/MapUtils.java
+++ b/deltaspike/core/api/src/main/java/org/apache/deltaspike/core/util/MapUtils.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.deltaspike.core.util;
+
+import jakarta.enterprise.inject.Typed;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.StringJoiner;
+
+/**
+ * Utility to flatten nested Maps into a single level key:value pair set of properties.
+ *
+ * @since 2.0.1
+ */
+@Typed
+public abstract class MapUtils
+{
+    /**
+     * Don't construct this class. Only use the <code>static</code> methods.
+     */
+    private MapUtils()
+    {
+        // Do nothing
+    }
+
+    /**
+     * Calls {@link #flattenMapProperties(Map, boolean)} with <code>indexed=false</code>.
+     *
+     * @param input Map of properties that may contain nested Maps.
+     * @param <V> Type of values the {@link Map} contains.
+     * @return Map of all properties indexed by their fully qualified names.
+     * @see #flattenMapProperties(Map, boolean)
+     */
+    public static <V> Map<String, String> flattenMapProperties(final Map<String, V> input)
+    {
+        return flattenMapProperties(input, false);
+    }
+
+    /**
+     * Converts a {@link Map} of objects to a flattened {@link Map} of {@link String} values.
+     *
+     * <p>For example, with the given input:</p>
+     *
+     * <pre><code>
+     * Map&lt;String, Object&gt; application = Map.of(
+     *     "name", "My App",
+     *     "prefixes", List.of("&gt;", "$")
+     * );
+     *
+     * Map&lt;String, Object&gt; map = Map.of("application", application);
+     * Map&lt;String, String&gt; result = MapUtils.flattenMapProperties(map);
+     * </code></pre>
+     *
+     * Will result in the following properties, assuming <code>indexed</code> is <code>false</code>:
+     *
+     * <pre><code>
+     * application.name=My App
+     * application.prefixes=&gt;,$
+     * </code></pre>
+     *
+     * If <code>indexed</code> is <code>true</code>, the result would be:
+     *
+     * <pre><code>
+     * application.name=My App
+     * application.prefixes[0]=&gt;
+     * application.prefixes[1]=$
+     * </code></pre>
+     *
+     *
+     * @param input Map of properties that may contain nested Maps.
+     * @param indexed If arrays are converted to multiple properties, or a comma separated list.
+     * @param <V> Type of values the {@link Map} contains.
+     * @return Map of all properties indexed by their fully qualified names.
+     */
+    public static <V> Map<String, String> flattenMapProperties(final Map<String, V> input, final boolean indexed)
+    {
+        final Map<String, String> result = new HashMap<>();
+        flattenMapProperties(input, result, indexed);
+        return result;
+    }
+
+    /**
+     * Calls {@link #flattenMapProperties(Map, Map, boolean, String)} with parameter <code>prefix</code> as <code>null</code>, since when we begin
+     * flattening the map, there is no prefix by default.
+     *
+     * @param input Map of properties that may contain nested Maps.
+     * @param output Map that all properties are added to.
+     * @param indexed If arrays are converted to multiple properties, or a comma separated list.
+     * @param <V> Type of values the {@link Map} contains.
+     * @see #flattenMapProperties(Map, Map, boolean, String)
+     */
+    private static <V> void flattenMapProperties(final Map<String, V> input,
+                                                 final Map<String, String> output,
+                                                 final boolean indexed)
+    {
+        flattenMapProperties(input, output, indexed, null);
+    }
+
+    /**
+     * @param input Map of properties that may contain nested Maps.
+     * @param output Map that all properties are added to.
+     * @param indexed If arrays are converted to multiple properties, or a comma separated list.
+     * @param prefix Name to prefix to any properties found on this level.
+     * @param <V> Type of values the {@link Map} contains.
+     */
+    private static <V> void flattenMapProperties(final Map<String, V> input,
+                                                 final Map<String, String> output,
+                                                 final boolean indexed,
+                                                 final String prefix)
+    {
+        input.forEach((key, value) ->
+            {
+                if (value == null)
+                {
+                    return;
+                }
+
+                final String k = (prefix == null) ? key : (prefix + '.' + key);
+
+                if (value instanceof Map)
+                {
+                    flattenMapProperties((Map) value, output, indexed, k);
+                }
+                else if (value instanceof Iterable)
+                {
+                    addIterable((Iterable) value, k, output, indexed);
+                }
+                else
+                {
+                    output.put(k, (output.containsKey(k)) ? output.get(k) + "," + value : value.toString());
+                }
+            });
+    }
+
+    /**
+     * @param value Array of values that needs to be flattened.
+     * @param key Property name for this value.
+     * @param output Map that all properties are added to.
+     * @param indexed If arrays are converted to multiple properties, or a comma separated list.
+     * @param <V> Type of values the {@link Map} contains.
+     */
+    private static <V> void addIterable(final Iterable<V> value,
+                                        final String key,
+                                        final Map<String, String> output,
+                                        final boolean indexed)
+    {
+        final StringJoiner joiner = new StringJoiner(",");
+        int index = 0;
+
+        for (final Object o : value)
+        {
+            if (o instanceof Map)
+            {
+                final Map map = (Map) o;
+
+                if (map.isEmpty())
+                {
+                    continue;
+                }
+
+                final String keyPrefix = (indexed) ? key + "[" + index++ + "]" : key;
+                flattenMapProperties((Map) map, output, indexed, keyPrefix);
+            }
+            else
+            {
+                joiner.add(o.toString());
+            }
+        }
+
+        if (joiner.length() > 0)
+        {
+            output.put(key, joiner.toString());
+        }
+    }
+}

--- a/deltaspike/core/api/src/test/java/org/apache/deltaspike/core/util/MapUtilsTest.java
+++ b/deltaspike/core/api/src/test/java/org/apache/deltaspike/core/util/MapUtilsTest.java
@@ -1,0 +1,332 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.deltaspike.core.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class MapUtilsTest
+{
+    /**
+     * <pre><code>
+     * application:
+     *   name: MyApp
+     * database:
+     *   host: 127.0.0.1
+     *   username: seth
+     *   password: password
+     * </code></pre>
+     */
+    @Test
+    public void testFlattenMap()
+    {
+        Map<String, String> application = new HashMap<>();
+        application.put("name", "MyApp");
+
+        Map<String, String> database = new HashMap<>();
+        database.put("host", "127.0.0.1");
+        database.put("username", "username");
+        database.put("password", "password");
+
+        Map<String, Object> map = new HashMap<>();
+        map.put("application", application);
+        map.put("database", database);
+
+        Map<String, String> result = MapUtils.flattenMapProperties(map);
+
+        Assert.assertEquals(4, result.size());
+        Assert.assertEquals("MyApp", result.get("application.name"));
+        Assert.assertEquals("127.0.0.1", result.get("database.host"));
+        Assert.assertEquals("username", result.get("database.username"));
+        Assert.assertEquals("password", result.get("database.password"));
+    }
+
+    /**
+     * <pre><code>
+     * application:
+     *   name: Another App
+     *   database:
+     *     host: localhost
+     *     username: username
+     *     password: password
+     * </code></pre>
+     */
+    @Test
+    public void testFlattenNestedMap()
+    {
+        Map<String, String> database = new HashMap<>();
+        database.put("host", "localhost");
+        database.put("username", "username");
+        database.put("password", "password");
+
+        Map<String, Object> application = new HashMap<>();
+        application.put("name", "Another App");
+        application.put("database", database);
+
+        Map<String, Object> map = new HashMap<>();
+        map.put("application", application);
+
+        Map<String, String> result = MapUtils.flattenMapProperties(map);
+
+        Assert.assertEquals(4, result.size());
+        Assert.assertEquals("Another App", result.get("application.name"));
+        Assert.assertEquals("localhost", result.get("application.database.host"));
+        Assert.assertEquals("username", result.get("application.database.username"));
+        Assert.assertEquals("password", result.get("application.database.password"));
+    }
+
+    /**
+     * <pre><code>
+     * application:
+     *   name: Yet Another App
+     *   prefixes:
+     *     - >
+     *     - $
+     * </code></pre>
+     */
+    @Test
+    public void testFlattenWithList()
+    {
+        List<String> prefixes = new ArrayList<>();
+        prefixes.add(">");
+        prefixes.add("$");
+
+        Map<String, Object> application = new HashMap<>();
+        application.put("name", "Yet Another App");
+        application.put("prefixes", prefixes);
+
+        Map<String, Object> map = new HashMap<>();
+        map.put("application", application);
+
+        Map<String, String> result = MapUtils.flattenMapProperties(map);
+
+        Assert.assertEquals(2, result.size());
+        Assert.assertEquals("Yet Another App", result.get("application.name"));
+        Assert.assertEquals(">,$", result.get("application.prefixes"));
+    }
+
+    /**
+     * <pre><code>
+     * application:
+     *   name: More Apps
+     *   messages:
+     *     - source: one
+     *       target: two
+     *     - source: three
+     *       target: four
+     * </code></pre>
+     */
+    @Test
+    public void testFlattenWithObjectArrayLists()
+    {
+        Map<String, String> message1 = new HashMap<>();
+        message1.put("source", "one");
+        message1.put("target", "two");
+
+        Map<String, String> message2 = new HashMap<>();
+        message2.put("source", "three");
+        message2.put("target", "four");
+
+        List<Map<String, String>> messages = new ArrayList<>();
+        messages.add(message1);
+        messages.add(message2);
+
+        Map<String, Object> application = new HashMap<>();
+        application.put("name", "More Apps");
+        application.put("messages", messages);
+
+        Map<String, Object> map = new HashMap<>();
+        map.put("application", application);
+
+        Map<String, String> result = MapUtils.flattenMapProperties(map);
+
+        Assert.assertEquals(3, result.size());
+        Assert.assertEquals("More Apps", result.get("application.name"));
+        Assert.assertEquals("one,three", result.get("application.messages.source"));
+        Assert.assertEquals("two,four", result.get("application.messages.target"));
+    }
+
+    /**
+     * Ignore nested null values.
+     *
+     * <pre><code>
+     * application:
+     *   name: More Apps
+     *   messages:
+     *     - source: one
+     *       target: two
+     *     - source: null
+     *       target: null
+     *     - source: three
+     *       target: four
+     * </code></pre>
+     */
+    @Test
+    public void testFlattenWithObjectArrayListsWithNull()
+    {
+        Map<String, String> message1 = new HashMap<>();
+        message1.put("source", "one");
+        message1.put("target", "two");
+
+        Map<String, String> message2 = new HashMap<>();
+        message2.put("source", null);
+        message2.put("target", null);
+
+        Map<String, String> message3 = new HashMap<>();
+        message2.put("source", "three");
+        message2.put("target", "four");
+
+        List<Map<String, String>> messages = new ArrayList<>();
+        messages.add(message1);
+        messages.add(message2);
+        messages.add(message3);
+
+        Map<String, Object> application = new HashMap<>();
+        application.put("name", "More Apps");
+        application.put("messages", messages);
+
+        Map<String, Object> map = new HashMap<>();
+        map.put("application", application);
+
+        Map<String, String> result = MapUtils.flattenMapProperties(map);
+
+        Assert.assertEquals(3, result.size());
+        Assert.assertEquals("More Apps", result.get("application.name"));
+        Assert.assertEquals("one,three", result.get("application.messages.source"));
+        Assert.assertEquals("two,four", result.get("application.messages.target"));
+    }
+
+    /**
+     * <pre><code>
+     * application:
+     *   name: More Apps
+     *   messages:
+     *     - source: one
+     *       target: two
+     *     - source: three
+     *       target: four
+     * </code></pre>
+     */
+    @Test
+    public void testFlattenWithObjectArrayIndexed()
+    {
+        Map<String, String> message1 = new HashMap<>();
+        message1.put("source", "one");
+        message1.put("target", "two");
+
+        Map<String, String> message2 = new HashMap<>();
+        message2.put("source", "three");
+        message2.put("target", "four");
+
+        List<Map<String, String>> messages = new ArrayList<>();
+        messages.add(message1);
+        messages.add(message2);
+
+        Map<String, Object> application = new HashMap<>();
+        application.put("name", "More Apps");
+        application.put("messages", messages);
+
+        Map<String, Object> map = new HashMap<>();
+        map.put("application", application);
+
+        Map<String, String> result = MapUtils.flattenMapProperties(map, true);
+
+        Assert.assertEquals(5, result.size());
+        Assert.assertEquals("More Apps", result.get("application.name"));
+        Assert.assertEquals("one", result.get("application.messages[0].source"));
+        Assert.assertEquals("two", result.get("application.messages[0].target"));
+        Assert.assertEquals("three", result.get("application.messages[1].source"));
+        Assert.assertEquals("four", result.get("application.messages[1].target"));
+    }
+
+    /**
+     * Ignore nested null values.
+     *
+     * <pre><code>
+     * application:
+     *   name: More Apps
+     *   messages:
+     *     - source: one
+     *       target: two
+     *     - source: null
+     *       target: null
+     *     - source: three
+     *       target: four
+     * </code></pre>
+     */
+    @Test
+    public void testFlattenWithObjectArrayIndexedWithNull()
+    {
+        Map<String, String> message1 = new HashMap<>();
+        message1.put("source", "one");
+        message1.put("target", "two");
+
+        Map<String, String> message2 = new HashMap<>();
+        message2.put("source", "three");
+        message2.put("target", "four");
+
+        List<Map<String, String>> messages = new ArrayList<>();
+        messages.add(message1);
+        messages.add(message2);
+
+        Map<String, Object> application = new HashMap<>();
+        application.put("name", "More Apps");
+        application.put("messages", messages);
+
+        Map<String, Object> map = new HashMap<>();
+        map.put("application", application);
+
+        Map<String, String> result = MapUtils.flattenMapProperties(map, true);
+
+        Assert.assertEquals(5, result.size());
+        Assert.assertEquals("More Apps", result.get("application.name"));
+        Assert.assertEquals("one", result.get("application.messages[0].source"));
+        Assert.assertEquals("two", result.get("application.messages[0].target"));
+        Assert.assertEquals("three", result.get("application.messages[1].source"));
+        Assert.assertEquals("four", result.get("application.messages[1].target"));
+    }
+
+    /**
+     * <pre><code>
+     * application:
+     *   name: Null App
+     *   prefixes:
+     * </code></pre>
+     */
+    @Test
+    public void testWithNull()
+    {
+        Map<String, Object> application = new HashMap<>();
+        application.put("name", "Null App");
+        application.put("prefixes", null);
+
+        Map<String, Object> map = new HashMap<>();
+        map.put("application", application);
+
+        Map<String, String> result = MapUtils.flattenMapProperties(map);
+
+        Assert.assertEquals(1, result.size());
+        Assert.assertEquals("Null App", result.get("application.name"));
+    }
+}

--- a/deltaspike/core/impl/src/main/java/org/apache/deltaspike/core/impl/config/EnvironmentPropertyConfigSource.java
+++ b/deltaspike/core/impl/src/main/java/org/apache/deltaspike/core/impl/config/EnvironmentPropertyConfigSource.java
@@ -18,8 +18,6 @@
  */
 package org.apache.deltaspike.core.impl.config;
 
-
-
 /**
  * {@link org.apache.deltaspike.core.spi.config.ConfigSource}
  * which uses {@link System#getenv()}
@@ -36,7 +34,6 @@ class EnvironmentPropertyConfigSource extends MapConfigSource
         initOrdinal(300);
     }
 
-    
     /**
      * {@inheritDoc}
      */

--- a/deltaspike/modules/yaml/api/pom.xml
+++ b/deltaspike/modules/yaml/api/pom.xml
@@ -17,32 +17,26 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.apache.deltaspike</groupId>
-        <artifactId>parent-code</artifactId>
+        <groupId>org.apache.deltaspike.modules</groupId>
+        <artifactId>yaml-module-project</artifactId>
         <version>2.0.1-SNAPSHOT</version>
-        <relativePath>../parent/code/pom.xml</relativePath>
     </parent>
 
-    <groupId>org.apache.deltaspike.modules</groupId>
-    <artifactId>modules-project</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
-    <packaging>pom</packaging>
+    <artifactId>deltaspike-yaml-module-api</artifactId>
 
-    <name>Apache DeltaSpike Modules</name>
+    <name>Apache DeltaSpike YAML-Module API</name>
 
-    <modules>
-        <module>proxy</module>
-        <module>security</module>
-        <module>jsf</module>
-        <module>partial-bean</module>
-        <module>jpa</module>
-        <module>data</module>
-        <module>scheduler</module>
-        <module>test-control</module>
-        <module>yaml</module>
-    </modules>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.deltaspike.core</groupId>
+            <artifactId>deltaspike-core-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/deltaspike/modules/yaml/impl/pom.xml
+++ b/deltaspike/modules/yaml/impl/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements. See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership. The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.deltaspike.modules</groupId>
+        <artifactId>yaml-module-project</artifactId>
+        <version>2.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>deltaspike-yaml-module-impl</artifactId>
+    <packaging>jar</packaging>
+    <name>Apache DeltaSpike YAML-Module Impl</name>
+    <properties>
+        <deltaspike.osgi.export.pkg>org.apache.deltaspike.yaml.impl.*</deltaspike.osgi.export.pkg>
+        <deltaspike.osgi.import>!org.apache.deltaspike.yaml.impl.*,*</deltaspike.osgi.import>
+        <cdi.osgi.beans-managed>META-INF/beans.xml</cdi.osgi.beans-managed>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.deltaspike.core</groupId>
+            <artifactId>deltaspike-core-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.deltaspike.core</groupId>
+            <artifactId>deltaspike-core-impl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>2.4</version>
+            <scope>compile</scope>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/deltaspike/modules/yaml/impl/src/main/java/org/apache/deltaspike/yaml/impl/YamlConfigSource.java
+++ b/deltaspike/modules/yaml/impl/src/main/java/org/apache/deltaspike/yaml/impl/YamlConfigSource.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.deltaspike.yaml.impl;
+
+import org.apache.deltaspike.core.impl.config.MapConfigSource;
+import org.apache.deltaspike.core.util.MapUtils;
+
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * You can create a configuration with a custom name by extending this class, and calling super() with the new configuration name.
+ *
+ * <pre><code>
+ * public class CustomYamlConfigSource extends YamlConfigSource
+ * {
+ *     public CustomYamlConfigSource()
+ *     {
+ *         super("custom_application.yml");
+ *     }
+ * }
+ * </code></pre>
+ *
+ * <p>This will seek out my_application.yml, instead of application.yml.</p>
+ *
+ * @since 2.0.1
+ */
+public class YamlConfigSource extends MapConfigSource
+{
+    /** Default configuration name. Already available if this class is in your classpath. */
+    private static final String DEFAULT_FILE_PATH = "application.yml";
+
+    /** Configuration file/stream name that the {@link YamlConfigSource} is for. */
+    private final String configName;
+
+    /**
+     * @see #isIndexed()
+     */
+    private final boolean indexed;
+
+    /** Constructs {@link YamlConfigSource} with {@link #DEFAULT_FILE_PATH}. */
+    public YamlConfigSource()
+    {
+        this(DEFAULT_FILE_PATH);
+    }
+
+    /**
+     * Calls {@link #YamlConfigSource(String, boolean)} with the parameter <code>indexed</code> set to false.
+     *
+     * @param configPath The file path relative to the classpath of the configuration.
+     * @throws NullPointerException If configPath is null.
+     * @see #YamlConfigSource(String, boolean)
+     */
+    public YamlConfigSource(String configPath)
+    {
+        this(configPath, false);
+    }
+
+    /**
+     * @param configPath File relative to the classpath of the configuration.
+     * @param indexed If this configuration should used indexed keys, or lists.
+     * @throws NullPointerException If configPath is null.
+     */
+    public YamlConfigSource(String configPath, boolean indexed)
+    {
+        this(new YamlStringFunction().apply(configPath), configPath, indexed);
+    }
+
+    /**
+     * @param inputStream Input stream to read the configuration from.
+     */
+    public YamlConfigSource(InputStream inputStream)
+    {
+        this(inputStream, false);
+    }
+
+    /**
+     * @param inputStream Input stream to read the configuration from.
+     * @param indexed If this configuration should used indexed keys, or lists.
+     */
+    public YamlConfigSource(InputStream inputStream, boolean indexed)
+    {
+        this(inputStream, "input-stream", indexed);
+    }
+
+    /**
+     * @param inputStream Input stream to read the configuration from.
+     * @param configName File path relative to the classpath of the configuration.
+     * @param indexed If this configuration should used indexed keys, or lists.
+     * @throws NullPointerException If configName is null.
+     */
+    public YamlConfigSource(InputStream inputStream, String configName, boolean indexed)
+    {
+        this(new YamlInputStreamFunction().apply(inputStream), configName, indexed);
+    }
+
+    /**
+     * @param map {@link Map}, which may include nested maps, of configuration properties.
+     * @param configName File path relative to the classpath of the configuration.
+     * @param indexed If this configuration should used indexed keys, or lists.
+     */
+    private YamlConfigSource(Map<String, Object> map, String configName, boolean indexed)
+    {
+        super(MapUtils.flattenMapProperties(map, indexed));
+        this.configName = Objects.requireNonNull(configName);
+        this.indexed = indexed;
+    }
+
+    @Override
+    public String getConfigName()
+    {
+        return "yaml " + configName;
+    }
+
+    /**
+     * If indexed is true, when we get arrays of objects such as:
+     *
+     * <pre><code>
+     * messages:
+     *   - source: one
+     *     target: two
+     *   - source: three
+     *     target: four
+     * </code></pre>
+     *
+     * It will return:
+     * <pre><code>
+     * messages[0].source=one
+     * messages[0].target=two
+     * messages[1].source=three
+     * messages[2].target=four
+     * </code></pre>
+     *
+     * <p>While if this is false (default), it would return:</p>
+     *
+     * <pre><code>
+     * messages.source=one,three
+     * messages.target=two,four
+     * </code></pre>
+     *
+     * @return If this {@link org.apache.deltaspike.core.spi.config.ConfigSource} uses indexed arrays, or comma separated values.
+     */
+    public boolean isIndexed()
+    {
+        return indexed;
+    }
+}

--- a/deltaspike/modules/yaml/impl/src/main/java/org/apache/deltaspike/yaml/impl/YamlInputStreamFunction.java
+++ b/deltaspike/modules/yaml/impl/src/main/java/org/apache/deltaspike/yaml/impl/YamlInputStreamFunction.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.deltaspike.yaml.impl;
+
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Java requires super be the first call of a method; we use this {@link Function} to perform more methods calls while calling super.
+ *
+ * @since 2.0.1
+ */
+public class YamlInputStreamFunction implements Function<InputStream, Map<String, Object>>
+{
+    private final Logger log = Logger.getLogger(YamlInputStreamFunction.class.getName());
+
+    /**
+     * @param inputStream Input stream to read the YAML configuration from.
+     * @return Nested map representing all YAML properties.
+     */
+    @Override
+    public Map<String, Object> apply(InputStream inputStream)
+    {
+        if (inputStream != null)
+        {
+            return new Yaml().load(inputStream);
+        }
+
+        log.log(Level.WARNING, "Using YamlConfigSource, but the stream was null.");
+        return new HashMap<>();
+    }
+}

--- a/deltaspike/modules/yaml/impl/src/main/java/org/apache/deltaspike/yaml/impl/YamlStringFunction.java
+++ b/deltaspike/modules/yaml/impl/src/main/java/org/apache/deltaspike/yaml/impl/YamlStringFunction.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.deltaspike.yaml.impl;
+
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Java requires super be the first call of a method; we use this {@link Function} to perform more methods calls while calling super.
+ *
+ * @since 2.0.1
+ */
+public class YamlStringFunction implements Function<String, Map<String, Object>>
+{
+    private final Logger log = Logger.getLogger(YamlStringFunction.class.getName());
+
+    /**
+     * @param configPath Path to the configuration file.
+     * @return Nested map representing all YAML properties.
+     */
+    @Override
+    public Map<String, Object> apply(String configPath)
+    {
+        try (InputStream inputStream = YamlConfigSource.class.getClassLoader().getResourceAsStream(configPath))
+        {
+            if (inputStream != null)
+            {
+                return new Yaml().load(inputStream);
+            }
+        }
+        catch (IOException ex)
+        {
+            log.log(Level.SEVERE, "IOException occurred while reading YAML.", ex);
+        }
+
+        log.log(Level.WARNING, "Using YamlConfigSource, but {0} was not found on the classpath.", configPath);
+        return new HashMap<>();
+    }
+}

--- a/deltaspike/modules/yaml/impl/src/main/resources/META-INF/services/org.apache.deltaspike.core.spi.config.ConfigSource
+++ b/deltaspike/modules/yaml/impl/src/main/resources/META-INF/services/org.apache.deltaspike.core.spi.config.ConfigSource
@@ -1,0 +1,20 @@
+#####################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#####################################################################################
+
+org.apache.deltaspike.yaml.impl.YamlConfigSource

--- a/deltaspike/modules/yaml/impl/src/test/java/org/apache/deltaspike/yaml/impl/YamlConfigSourceTest.java
+++ b/deltaspike/modules/yaml/impl/src/test/java/org/apache/deltaspike/yaml/impl/YamlConfigSourceTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.deltaspike.yaml.impl;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+public class YamlConfigSourceTest
+{
+    /**
+     * It should <strong>not</strong> throw an error in the case this file does not exist.
+     */
+    @Test
+    public void exceptionNotThrownOnDefaultConfiguration()
+    {
+        try
+        {
+            new YamlConfigSource();
+        }
+        catch (Exception ex)
+        {
+            Assert.fail();
+        }
+    }
+
+    @Test
+    public void testThatInputStreamWorks() throws IOException
+    {
+        String yaml =
+            "application:\n"    +
+            "  name: Testing";
+
+        try (InputStream stream = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)))
+        {
+            YamlConfigSource config = new YamlConfigSource(stream);
+
+            Assert.assertEquals("yaml input-stream", config.getConfigName());
+            Assert.assertFalse(config.isIndexed());
+            Assert.assertEquals("Testing", config.getPropertyValue("application.name"));
+        }
+    }
+
+    @Test
+    public void testInputStreamWithCustomName() throws IOException
+    {
+        String yaml =
+            "application:\n"    +
+            "  name: Testing";
+
+        try (InputStream stream = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)))
+        {
+            YamlConfigSource config = new YamlConfigSource(stream, "custom-stream", true);
+
+            Assert.assertEquals("yaml custom-stream", config.getConfigName());
+            Assert.assertTrue(config.isIndexed());
+            Assert.assertEquals("Testing", config.getPropertyValue("application.name"));
+        }
+    }
+
+    @Test
+    public void testWithNullInputStream()
+    {
+        try
+        {
+            new YamlConfigSource((InputStream)null);
+        }
+        catch (Exception ex)
+        {
+            Assert.fail();
+        }
+    }
+}

--- a/deltaspike/modules/yaml/pom.xml
+++ b/deltaspike/modules/yaml/pom.xml
@@ -17,32 +17,25 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.apache.deltaspike</groupId>
-        <artifactId>parent-code</artifactId>
+        <groupId>org.apache.deltaspike.modules</groupId>
+        <artifactId>modules-project</artifactId>
         <version>2.0.1-SNAPSHOT</version>
-        <relativePath>../parent/code/pom.xml</relativePath>
     </parent>
 
     <groupId>org.apache.deltaspike.modules</groupId>
-    <artifactId>modules-project</artifactId>
+    <artifactId>yaml-module-project</artifactId>
     <version>2.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <name>Apache DeltaSpike Modules</name>
+    <name>Apache DeltaSpike YAML-Module</name>
 
     <modules>
-        <module>proxy</module>
-        <module>security</module>
-        <module>jsf</module>
-        <module>partial-bean</module>
-        <module>jpa</module>
-        <module>data</module>
-        <module>scheduler</module>
-        <module>test-control</module>
-        <module>yaml</module>
+        <module>api</module>
+        <module>impl</module>
     </modules>
 </project>


### PR DESCRIPTION
Adds a new module under `org.apache.deltaspike.modules:deltaspike-yaml-module-impl`, which includes an implementation of `ConfigSource` for YAML.

The new module depends on snakeyaml.

The logic was migrated from an external package I wrote and published. If this is merged, that project can be archived/deprecated:

* https://github.com/SethFalco/yaml4deltaspike
