### PR TITLE
DELTASPIKE-1416: add maven-jar-plugin to to use the MANIFEST.MF

### DIFF
--- a/deltaspike/core/impl/pom.xml
+++ b/deltaspike/core/impl/pom.xml
@@ -77,5 +77,18 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>src/main/resources/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>
 


### PR DESCRIPTION
link to Jira: https://issues.apache.org/jira/browse/DELTASPIKE-1416

In https://deltaspike.apache.org/documentation/encryption.html

demo how to run java -jar deltaspike-core-impl.jar encode -masterPassword myMasterPassword -masterSalt myMasterSalt

more in your MANIFEST.MF does not contain the Main-Class that is in META-INF of the Core:

https://github.com/apache/deltaspike/blob/master/deltaspike/core/impl/src/main/resources/META-INF/MANIFEST.MF

 

to resolve, you must include a plugin:

```
<plugin>
 <groupId>org.apache.maven.plugins</groupId>
 <artifactId>maven-jar-plugin</artifactId>
 <configuration>
 <archive>
 <manifestFile>src/main/resources/META-INF/MANIFEST.MF</manifestFile>
 </archive>
 </configuration>
 </plugin>
```
 