### PR TITLE
DELTASPIKE-1435 Add SameSite=Strict to windowhandler.js

### DIFF
--- a/deltaspike/modules/jsf/impl/src/main/resources/META-INF/resources/deltaspike/windowhandler.js
+++ b/deltaspike/modules/jsf/impl/src/main/resources/META-INF/resources/deltaspike/windowhandler.js
@@ -600,7 +600,7 @@ window.dswh = window.dswh || {
             date.setTime(date.getTime()-(10*24*60*60*1000)); // - 10 day
             var expires = ";max-age=0;expires=" + date.toGMTString();
 
-            document.cookie = cookieName + "=" + expires + "; path=/";
+            document.cookie = cookieName + "=" + expires + "; path=/; SameSite=Strict";
         },
 
         generateNewRequestToken : function() {
@@ -616,7 +616,7 @@ window.dswh = window.dswh || {
             expiresDate.setTime(expiresDate.getTime() + (seconds * 1000));
             var expires = "; expires=" + expiresDate.toGMTString();
 
-            document.cookie = name + '=' + value + expires + "; path=/";
+            document.cookie = name + '=' + value + expires + "; path=/; SameSite=Strict";
         },
 
         log : function(message) {


### PR DESCRIPTION
Firefox complains about the missing flag, and announces, that the Cookie
"will be soon rejected". Enforcing SameSite=Strict in JavaScript (as
already done on server side makes Firefox happy, and hence the warning go
away.

https://issues.apache.org/jira/browse/DELTASPIKE-1435