### PR TITLE
DELTASPIKE-1434 - Refine relocation patterns for javax -> jakarta 

### DIFF
--- a/deltaspike/parent/code/pom.xml
+++ b/deltaspike/parent/code/pom.xml
@@ -164,10 +164,36 @@
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>jakarta</shadedClassifierName>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                            </transformers>
                             <relocations>
                                 <relocation>
-                                    <pattern>javax</pattern>
-                                    <shadedPattern>jakarta</shadedPattern>
+                                    <pattern>javax.inject</pattern>
+                                    <shadedPattern>jakarta.inject</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>javax.interceptor</pattern>
+                                    <shadedPattern>jakarta.interceptor</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>javax.enterprise</pattern>
+                                    <shadedPattern>jakarta.enterprise</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>javax.resource</pattern>
+                                    <shadedPattern>jakarta.resource</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>javax.transaction</pattern>
+                                    <shadedPattern>jakarta.transaction</shadedPattern>
+                                    <excludes>
+                                        <exclude>javax.transaction.xa.**</exclude>
+                                    </excludes>
+                                </relocation>
+                                <relocation>
+                                    <pattern>javax.validation</pattern>
+                                    <shadedPattern>jakarta.validation</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>


### PR DESCRIPTION
# Summary

While working on fixing deltaspike examples in TomEE 9.0.0-M8-SNAPSHOT, I encountered some issues regarding the relocated articafts in Deltaspike 1.9.6

I did some refinements as the transformation javax -> jakarta does not apply for everything in the javax namespace.

# What does this PR do ?

- Refines relocation patterns for javax -> jakarta
- Adds service transformer to transform `META-INF/services` files as well

