### PR TITLE
DELTASPIKE-1434 - Adds relocation pattern for javax.persistence

### DIFF
--- a/deltaspike/parent/code/pom.xml
+++ b/deltaspike/parent/code/pom.xml
@@ -195,6 +195,10 @@
                                     <pattern>javax.validation</pattern>
                                     <shadedPattern>jakarta.validation</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>javax.persistence</pattern>
+                                    <shadedPattern>jakarta.persistence</shadedPattern>
+                                </relocation>
                             </relocations>
                         </configuration>
                     </execution>


### PR DESCRIPTION
# What does this PR do?

I missed javax.persistence -> jakarta.persistence in the last PR. This PR adds this additional relocation, so we hopefully now have all relevant relocations in place

Found while working on fixing some other (Krazo/MVC) TomEE 9.0.0-M8-SNAPSHOT examples. 

@struberg Maybe you can deploy a new snapshot afterwards.