### PR TITLE
[pom] Add jakarta.el at 3.0.4 for jdk9+ needed for hibernate-validator

### DIFF
--- a/deltaspike/parent/code/pom.xml
+++ b/deltaspike/parent/code/pom.xml
@@ -260,6 +260,13 @@
                 <validation.artifactId>geronimo-validation_2.0_spec</validation.artifactId>
                 <hibernate.validator.version>6.0.17.Final</hibernate.validator.version>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.glassfish</groupId>
+                    <artifactId>jakarta.el</artifactId>
+                    <version>3.0.4</version>
+                </dependency>
+            </dependencies>
         </profile>
         
         <profile>


### PR DESCRIPTION
Tested this was required at jdk 17.  Was not at jdk 8.  Assuming its jdk9+ issue but didn't further confirm.  Was originally part of #124 with further information there.