### PR TITLE
Annotate DelegateQueryHandler for DelegateQueryBuilder.lookup of methods

### DIFF
--- a/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/handler/EntityManagerDelegateHandler.java
+++ b/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/handler/EntityManagerDelegateHandler.java
@@ -20,6 +20,7 @@ package org.apache.deltaspike.data.impl.handler;
 
 import java.util.Map;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
@@ -34,6 +35,7 @@ import org.apache.deltaspike.data.spi.DelegateQueryHandler;
 import org.apache.deltaspike.data.spi.QueryInvocationContext;
 
 @SuppressWarnings("unchecked")
+@Dependent
 public class EntityManagerDelegateHandler<E> implements EntityManagerDelegate<E>, DelegateQueryHandler
 {
 

--- a/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/handler/EntityRepositoryHandler.java
+++ b/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/handler/EntityRepositoryHandler.java
@@ -29,6 +29,7 @@ import org.apache.deltaspike.data.impl.util.EntityUtils;
 import org.apache.deltaspike.data.impl.util.jpa.PersistenceUnitUtilDelegateFactory;
 import org.apache.deltaspike.data.spi.DelegateQueryHandler;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceUnitUtil;
@@ -56,6 +57,7 @@ import static org.apache.deltaspike.data.impl.util.QueryUtils.isString;
  * @param <E>  Entity type.
  * @param <PK> Primary key type, must be a serializable.
  */
+@Dependent
 public class EntityRepositoryHandler<E, PK extends Serializable>
         implements EntityRepository<E, PK>, DelegateQueryHandler
 {

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/service/MyEntityRepositoryDelegate.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/service/MyEntityRepositoryDelegate.java
@@ -18,12 +18,14 @@
  */
 package org.apache.deltaspike.data.test.service;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 
 import org.apache.deltaspike.data.spi.DelegateQueryHandler;
 import org.apache.deltaspike.data.spi.QueryInvocationContext;
 
+@Dependent
 public class MyEntityRepositoryDelegate<E> implements DelegateQueryHandler, MyEntityRepository<E>
 {
 


### PR DESCRIPTION
Every DelegateQueryHandler needs annotation for BeanManager to find during DelegateQueryBuilder.lookup when building abstract method cache.