### PR TITLE
NPE in WeldContainerControl on missing default test-container config

### DIFF
--- a/deltaspike/cdictrl/impl-weld/src/main/java/org/apache/deltaspike/cdise/weld/WeldContainerControl.java
+++ b/deltaspike/cdictrl/impl-weld/src/main/java/org/apache/deltaspike/cdise/weld/WeldContainerControl.java
@@ -31,6 +31,7 @@ import jakarta.enterprise.inject.spi.BeanManager;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
@@ -207,6 +208,10 @@ public class WeldContainerControl implements CdiContainer
     
     private static Map<String, Object> convertProperties(final Map<?, ?> map)
     {
+        if (map == null)
+        {
+            return Collections.emptyMap();
+        }
         return map.entrySet().stream()
                 .collect(Collectors.toMap(
                         entry -> String.valueOf(entry.getKey()),

--- a/deltaspike/modules/test-control/api/src/main/java/org/apache/deltaspike/testcontrol/api/junit/CdiTestRunner.java
+++ b/deltaspike/modules/test-control/api/src/main/java/org/apache/deltaspike/testcontrol/api/junit/CdiTestRunner.java
@@ -478,7 +478,9 @@ public class CdiTestRunner extends BlockJUnit4ClassRunner
                     // enabled globally
                     // Beginning with Weld 2.x you could use Weld.property(), but here we depend on Weld 1.x API
                     // Note that Weld 1 was "flat" anyway, so this property only affects newer versions of Weld
-                    System.setProperty("org.jboss.weld.se.archive.isolation", "false");
+                    // System.setProperty("org.jboss.weld.se.archive.isolation", "false");
+                    // Weld 5.0: https://docs.jboss.org/weld/reference/5.0.0.Final/en-US/html_single/#_bean_archive_isolation
+                    System.setProperty("org.jboss.weld.environment.servlet.archive.isolation", "false");
 
                     CdiTestSuiteRunner.applyTestSpecificMetaData(testClass);
 

--- a/deltaspike/modules/test-control/impl/src/main/resources/META-INF/apache-deltaspike_test-container.properties
+++ b/deltaspike/modules/test-control/impl/src/main/resources/META-INF/apache-deltaspike_test-container.properties
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+
+#can be used to configure the underlying test-container
+#(currently the only container supported by deltaspike
+#(out-of-the-box) which supports that config is openejb-embedded)
+


### PR DESCRIPTION
1) Archive Isolation: 
    Weld 5 has moved to property: "org.jboss.weld.environment.servlet.archive.isolation"
    [Weld Reference 5.0.0#_bean_archive_isolation](https://docs.jboss.org/weld/reference/5.0.0.Final/en-US/html_single/#_bean_archive_isolation)

2) NPE in WeldContainerControl:
  - handle missing default test-container config gracefully
  - add an empty test-container properties file

```
java.lang.NullPointerException: Cannot invoke "java.util.Map.entrySet()" because "map" is null
        at org.apache.deltaspike.cdise.weld.WeldContainerControl.convertProperties(WeldContainerControl.java:210)
        at org.apache.deltaspike.cdise.weld.WeldContainerControl.boot(WeldContainerControl.java:84)
        at org.apache.deltaspike.testcontrol.api.junit.CdiTestRunner$ContainerAwareTestContext.applyBeforeClassConfig(CdiTestRunner.java:485)
```