### PR TITLE
Reenabled examples - move to TomEE-API 10.0-M2 and TomEE-10-SNAPSHOT

### DIFF
--- a/deltaspike/examples/data-examples/pom.xml
+++ b/deltaspike/examples/data-examples/pom.xml
@@ -80,11 +80,16 @@
         </dependency>
 
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>7.0</version>
-            <scope>provided</scope>
+            <groupId>org.apache.tomee</groupId>
+            <artifactId>jakartaee-api</artifactId>
         </dependency>
+        
+        <dependency>
+            <groupId>org.apache.myfaces.core</groupId>
+            <artifactId>myfaces-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        
     </dependencies>
 
     <build>

--- a/deltaspike/examples/data-examples/src/main/java/org/apache/deltaspike/example/ArticleController.java
+++ b/deltaspike/examples/data-examples/src/main/java/org/apache/deltaspike/example/ArticleController.java
@@ -23,7 +23,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.logging.Logger;
 import jakarta.faces.application.FacesMessage;
-import jakarta.faces.bean.ViewScoped;
+import jakarta.faces.view.ViewScoped;
 import jakarta.faces.context.FacesContext;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;

--- a/deltaspike/examples/jpa-examples/pom.xml
+++ b/deltaspike/examples/jpa-examples/pom.xml
@@ -70,11 +70,16 @@
         </dependency>
 
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>7.0</version>
-            <scope>provided</scope>
+            <groupId>org.apache.tomee</groupId>
+            <artifactId>jakartaee-api</artifactId>
         </dependency>
+        
+        <dependency>
+            <groupId>org.apache.myfaces.core</groupId>
+            <artifactId>myfaces-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        
     </dependencies>
 
     <build>

--- a/deltaspike/examples/jpa-examples/src/main/java/org/apache/deltaspike/example/ArticleController.java
+++ b/deltaspike/examples/jpa-examples/src/main/java/org/apache/deltaspike/example/ArticleController.java
@@ -23,7 +23,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.logging.Logger;
 import jakarta.faces.application.FacesMessage;
-import jakarta.faces.bean.ViewScoped;
+import jakarta.faces.view.ViewScoped;
 import jakarta.faces.context.FacesContext;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;

--- a/deltaspike/examples/jse-examples/pom.xml
+++ b/deltaspike/examples/jse-examples/pom.xml
@@ -66,12 +66,14 @@
                 <dependency>
                     <groupId>org.apache.openwebbeans</groupId>
                     <artifactId>openwebbeans-impl</artifactId>
+                    <version>${owb.version}</version>
                     <scope>runtime</scope>
                 </dependency>
 
                 <dependency>
                     <groupId>org.apache.openwebbeans</groupId>
                     <artifactId>openwebbeans-spi</artifactId>
+                    <version>${owb.version}</version>
                     <scope>compile</scope>
                 </dependency>
 
@@ -107,25 +109,22 @@
         <dependency>
             <groupId>org.apache.deltaspike.core</groupId>
             <artifactId>deltaspike-core-api</artifactId>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.deltaspike.core</groupId>
             <artifactId>deltaspike-core-impl</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.deltaspike.modules</groupId>
-            <artifactId>deltaspike-security-module-api</artifactId>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.deltaspike.modules</groupId>
+            <artifactId>deltaspike-security-module-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.deltaspike.modules</groupId>
             <artifactId>deltaspike-security-module-impl</artifactId>
-            <scope>runtime</scope>
         </dependency>
 
         <!-- Dependencies for Java-SE -->
@@ -135,12 +134,6 @@
             <scope>compile</scope>
         </dependency>
 
-        <!-- TODO refactoring - this dependency shouldn't be needed -->
-        <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-servlet_2.5_spec</artifactId>
-            <scope>runtime</scope>
-        </dependency>
     </dependencies>
 </project>
 

--- a/deltaspike/examples/jse-examples/src/main/java/org/apache/deltaspike/example/metadata/NamingConventionAwareMetadataFilter.java
+++ b/deltaspike/examples/jse-examples/src/main/java/org/apache/deltaspike/example/metadata/NamingConventionAwareMetadataFilter.java
@@ -18,13 +18,9 @@
  */
 package org.apache.deltaspike.example.metadata;
 
-import org.apache.deltaspike.core.api.literal.NamedLiteral;
-import org.apache.deltaspike.core.util.metadata.builder.AnnotatedTypeBuilder;
-
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.spi.Extension;
 import jakarta.enterprise.inject.spi.ProcessAnnotatedType;
-import jakarta.inject.Named;
 
 /**
  * Just a test filter to show the basic functionality provided by {@link AnnotatedTypeBuilder}
@@ -35,21 +31,21 @@ public class NamingConventionAwareMetadataFilter implements Extension
     {
         Class<?> beanClass = processAnnotatedType.getAnnotatedType().getJavaClass();
 
-        Named namedAnnotation = beanClass.getAnnotation(Named.class);
-        if (namedAnnotation != null &&
-                namedAnnotation.value().length() > 0 &&
-                Character.isUpperCase(namedAnnotation.value().charAt(0)))
-        {
-            AnnotatedTypeBuilder builder = new AnnotatedTypeBuilder();
-            builder.readFromType(beanClass);
-
-            String beanName = namedAnnotation.value();
-            String newBeanName = beanName.substring(0, 1).toLowerCase() + beanName.substring(1);
-
-            builder.removeFromClass(Named.class)
-                    .addToClass(new NamedLiteral(newBeanName));
-
-            processAnnotatedType.setAnnotatedType(builder.create());
-        }
+//        Named namedAnnotation = beanClass.getAnnotation(Named.class);
+//        if (namedAnnotation != null &&
+//                namedAnnotation.value().length() > 0 &&
+//                Character.isUpperCase(namedAnnotation.value().charAt(0)))
+//        {
+//            AnnotatedTypeBuilder builder = new AnnotatedTypeBuilder();
+//            builder.readFromType(beanClass);
+//
+//            String beanName = namedAnnotation.value();
+//            String newBeanName = beanName.substring(0, 1).toLowerCase() + beanName.substring(1);
+//
+//            builder.removeFromClass(Named.class)
+//                    .addToClass(new NamedLiteral(newBeanName));
+//
+//            processAnnotatedType.setAnnotatedType(builder.create());
+//        }
     }
 }

--- a/deltaspike/examples/jsf-examples/pom.xml
+++ b/deltaspike/examples/jsf-examples/pom.xml
@@ -88,15 +88,11 @@
 
         <dependency>
             <groupId>org.apache.tomee</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>6.0-5</version>
-            <scope>provided</scope>
+            <artifactId>jakartaee-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.myfaces.core</groupId>
             <artifactId>myfaces-api</artifactId>
-            <version>${myfaces2.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <!-- DeltaSpike modules -->

--- a/deltaspike/examples/jsf-examples/src/main/java/org/apache/deltaspike/example/scope/ViewScopedBean.java
+++ b/deltaspike/examples/jsf-examples/src/main/java/org/apache/deltaspike/example/scope/ViewScopedBean.java
@@ -19,7 +19,7 @@
 package org.apache.deltaspike.example.scope;
 
 import jakarta.annotation.PostConstruct;
-import jakarta.faces.bean.ViewScoped;
+import jakarta.faces.view.ViewScoped;
 import jakarta.inject.Named;
 import java.io.Serializable;
 

--- a/deltaspike/examples/jsf-playground/pom.xml
+++ b/deltaspike/examples/jsf-playground/pom.xml
@@ -60,27 +60,32 @@
         <dependency>
             <groupId>org.apache.deltaspike.core</groupId>
             <artifactId>deltaspike-core-api</artifactId>
-            <scope>compile</scope>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.deltaspike.core</groupId>
             <artifactId>deltaspike-core-impl</artifactId>
             <scope>compile</scope>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.deltaspike.modules</groupId>
             <artifactId>deltaspike-jsf-module-api</artifactId>
-            <scope>compile</scope>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.deltaspike.modules</groupId>
             <artifactId>deltaspike-jsf-module-impl</artifactId>
             <scope>compile</scope>
-            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.tomee</groupId>
+            <artifactId>jakartaee-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.myfaces.core</groupId>
+            <artifactId>myfaces-api</artifactId>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/deltaspike/examples/jsf-playground/src/main/java/org/apache/deltaspike/playground/PlaygroundClientWindowConfig.java
+++ b/deltaspike/examples/jsf-playground/src/main/java/org/apache/deltaspike/playground/PlaygroundClientWindowConfig.java
@@ -18,9 +18,10 @@
  */
 package org.apache.deltaspike.playground;
 
+import org.apache.deltaspike.jsf.spi.scope.window.DefaultClientWindowConfig;
+
 import jakarta.enterprise.inject.Specializes;
 import jakarta.faces.context.FacesContext;
-import org.apache.deltaspike.jsf.spi.scope.window.DefaultClientWindowConfig;
 
 @Specializes
 public class PlaygroundClientWindowConfig extends DefaultClientWindowConfig

--- a/deltaspike/examples/pom.xml
+++ b/deltaspike/examples/pom.xml
@@ -51,39 +51,145 @@
     <packaging>pom</packaging>
 
     <name>Apache DeltaSpike Examples</name>
-
+    
     <modules>
-        <!--
         <module>jse-examples</module>
         <module>jsf-examples</module>
-        -->
         <module>jsf-playground</module>
-        <!--
         <module>security-requested-page-after-login-cdi</module>
         <module>security-requested-page-after-login-picketlink</module>
         <module>scheduler-playground</module>
         <module>jpa-examples</module>
         <module>data-examples</module>
-        -->
     </modules>
 
     <properties>
         <deploy.skip>false</deploy.skip>
+        <deltaspike.examples.version>${project.version}</deltaspike.examples.version>
     </properties>
 
+	<dependencyManagement>
+		<dependencies>
+	        <dependency>
+	            <groupId>org.apache.deltaspike.core</groupId>
+	            <artifactId>deltaspike-core-api</artifactId>
+	            <version>${deltaspike.examples.version}</version>
+	        </dependency>
+	
+	        <dependency>
+	            <groupId>org.apache.deltaspike.core</groupId>
+	            <artifactId>deltaspike-core-impl</artifactId>
+	            <version>${deltaspike.examples.version}</version>
+	            <scope>runtime</scope>
+	        </dependency>
+	        
+	        <dependency>
+	            <groupId>org.apache.deltaspike.modules</groupId>
+	            <artifactId>deltaspike-security-module-api</artifactId>
+	            <version>${deltaspike.examples.version}</version>
+	        </dependency>
+	
+	        <dependency>
+	            <groupId>org.apache.deltaspike.modules</groupId>
+	            <artifactId>deltaspike-security-module-impl</artifactId>
+	            <version>${deltaspike.examples.version}</version>
+	            <scope>runtime</scope>
+	        </dependency>
+	
+	        <dependency>
+	            <groupId>org.apache.deltaspike.modules</groupId>
+	            <artifactId>deltaspike-jsf-module-api</artifactId>
+	            <version>${deltaspike.examples.version}</version>
+	        </dependency>
+
+	        <dependency>
+	            <groupId>org.apache.deltaspike.modules</groupId>
+	            <artifactId>deltaspike-jsf-module-impl</artifactId>
+	            <version>${deltaspike.examples.version}</version>
+	            <scope>runtime</scope>
+	        </dependency>
+
+	        <dependency>
+	            <groupId>org.apache.deltaspike.modules</groupId>
+	            <artifactId>deltaspike-jpa-module-api</artifactId>
+	            <version>${deltaspike.examples.version}</version>
+	        </dependency>
+
+	        <dependency>
+	            <groupId>org.apache.deltaspike.modules</groupId>
+	            <artifactId>deltaspike-jpa-module-impl</artifactId>
+	            <version>${deltaspike.examples.version}</version>
+	            <scope>runtime</scope>
+	        </dependency>
+
+	        <dependency>
+	            <groupId>org.apache.deltaspike.modules</groupId>
+	            <artifactId>deltaspike-data-module-api</artifactId>
+	            <version>${deltaspike.examples.version}</version>
+	        </dependency>
+
+	        <dependency>
+	            <groupId>org.apache.deltaspike.modules</groupId>
+	            <artifactId>deltaspike-data-module-impl</artifactId>
+	            <version>${deltaspike.examples.version}</version>
+	            <scope>runtime</scope>
+	        </dependency>
+
+	        <dependency>
+	            <groupId>org.apache.deltaspike.modules</groupId>
+	            <artifactId>deltaspike-scheduler-module-api</artifactId>
+	            <version>${deltaspike.examples.version}</version>
+	        </dependency>
+
+	        <dependency>
+	            <groupId>org.apache.deltaspike.modules</groupId>
+	            <artifactId>deltaspike-scheduler-module-impl</artifactId>
+	            <version>${deltaspike.examples.version}</version>
+	            <scope>runtime</scope>
+	        </dependency>
+
+	        <dependency>
+	            <groupId>org.apache.deltaspike.cdictrl</groupId>
+	            <artifactId>deltaspike-cdictrl-api</artifactId>
+	            <version>${deltaspike.examples.version}</version>
+	        </dependency>
+
+	        <dependency>
+	            <groupId>org.apache.deltaspike.cdictrl</groupId>
+	            <artifactId>deltaspike-cdictrl-owb</artifactId>
+	            <version>${deltaspike.examples.version}</version>
+	        </dependency>
+
+	        <dependency>
+	            <groupId>org.apache.deltaspike.cdictrl</groupId>
+	            <artifactId>deltaspike-cdictrl-openejb</artifactId>
+	            <version>${deltaspike.examples.version}</version>
+	        </dependency>
+
+	        <dependency>
+	            <groupId>org.apache.deltaspike.cdictrl</groupId>
+	            <artifactId>deltaspike-cdictrl-weld</artifactId>
+	            <version>${deltaspike.examples.version}</version>
+	        </dependency>
+
+	        <dependency>
+	            <groupId>org.apache.tomee</groupId>
+	            <artifactId>jakartaee-api</artifactId>
+	            <version>${tomee-api.version}</version>
+	            <scope>provided</scope>
+	        </dependency>
+	        
+	        <dependency>
+	            <groupId>org.apache.myfaces.core</groupId>
+	            <artifactId>myfaces-api</artifactId>
+	            <version>${myfaces.version}</version>
+	            <scope>provided</scope>
+	        </dependency>
+
+		</dependencies>
+	</dependencyManagement>
+
     <dependencies>
-        <dependency>
-            <groupId>org.apache.tomee</groupId>
-            <artifactId>jakartaee-api</artifactId>
-            <version>10.0-M2</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.myfaces.core</groupId>
-            <artifactId>myfaces-api</artifactId>
-            <version>4.0.1</version>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <build>
@@ -91,6 +197,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.1.1</version>
                 <configuration>
                     <skip>${deploy.skip}</skip> <!-- we don't deploy our samples upstream -->
                 </configuration>

--- a/deltaspike/examples/scheduler-playground/pom.xml
+++ b/deltaspike/examples/scheduler-playground/pom.xml
@@ -66,12 +66,14 @@
                 <dependency>
                     <groupId>org.apache.openwebbeans</groupId>
                     <artifactId>openwebbeans-impl</artifactId>
+                    <version>${owb.version}</version>
                     <scope>runtime</scope>
                 </dependency>
 
                 <dependency>
                     <groupId>org.apache.openwebbeans</groupId>
                     <artifactId>openwebbeans-spi</artifactId>
+                    <version>${owb.version}</version>
                     <scope>compile</scope>
                 </dependency>
 
@@ -144,12 +146,6 @@
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz</artifactId>
             <version>2.3.2</version>
-        </dependency>
-        <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>7.0</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/deltaspike/examples/security-requested-page-after-login-cdi/pom.xml
+++ b/deltaspike/examples/security-requested-page-after-login-cdi/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.apache.myfaces.core</groupId>
             <artifactId>myfaces-api</artifactId>
-            <version>${myfaces2.version}</version>
+            <version>${myfaces.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -98,6 +98,11 @@
             <groupId>org.apache.deltaspike.modules</groupId>
             <artifactId>deltaspike-security-module-impl</artifactId>
             <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.tomee</groupId>
+            <artifactId>jakartaee-api</artifactId>
         </dependency>
 
     </dependencies>

--- a/deltaspike/examples/security-requested-page-after-login-picketlink/pom.xml
+++ b/deltaspike/examples/security-requested-page-after-login-picketlink/pom.xml
@@ -59,7 +59,6 @@
         <dependency>
             <groupId>org.apache.myfaces.core</groupId>
             <artifactId>myfaces-api</artifactId>
-            <version>${myfaces2.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -116,8 +115,7 @@
 
         <dependency>
             <groupId>org.apache.tomee</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>6.0-6</version>
+            <artifactId>jakartaee-api</artifactId>
         </dependency>
 
     </dependencies>

--- a/deltaspike/parent/code/pom.xml
+++ b/deltaspike/parent/code/pom.xml
@@ -596,7 +596,7 @@
             <id>wildfly-managed</id>
             <properties>
                 <!-- Actual default Weld version used with this profile -->
-                <weld.version>2.3.5.Final</weld.version>
+                <weld.version>5.0.1.Final</weld.version>
                 <cdicontainer.version>wildfly-${wildfly.version}</cdicontainer.version>
             </properties>
 
@@ -607,12 +607,6 @@
                     <groupId>org.jboss.weld</groupId>
                     <artifactId>weld-core-impl</artifactId>
                     <version>${weld.version}</version>
-                    <scope>provided</scope>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.inject</groupId>
-                    <artifactId>jakarta.inject</artifactId>
-                    <version>1</version>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>

--- a/deltaspike/parent/pom.xml
+++ b/deltaspike/parent/pom.xml
@@ -56,7 +56,8 @@
         <!-- for cdictrl-openejb -->
         <openejb.version>9.1.1</openejb.version>
         <tomee10.version>10.0.0-M1-SNAPSHOT</tomee10.version>
-        <tomee.version>${tomee10.version}</tomee.version>
+        <tomee.version>9.1.2</tomee.version>
+        <tomee-api.version>9.1.1</tomee-api.version>
 
         <openejb.owb.version>${owb.version}</openejb.owb.version>
 

--- a/deltaspike/parent/pom.xml
+++ b/deltaspike/parent/pom.xml
@@ -57,7 +57,7 @@
         <openejb.version>9.1.1</openejb.version>
         <tomee10.version>10.0.0-M1-SNAPSHOT</tomee10.version>
         <tomee.version>${tomee10.version}</tomee.version>
-        <tomee-api.version>10.0-SNAPSHOT</tomee-api.version>
+        <tomee-api.version>10.0-M2</tomee-api.version>
 
         <openejb.owb.version>${owb.version}</openejb.owb.version>
 

--- a/deltaspike/parent/pom.xml
+++ b/deltaspike/parent/pom.xml
@@ -56,8 +56,8 @@
         <!-- for cdictrl-openejb -->
         <openejb.version>9.1.1</openejb.version>
         <tomee10.version>10.0.0-M1-SNAPSHOT</tomee10.version>
-        <tomee.version>9.1.2</tomee.version>
-        <tomee-api.version>9.1.1</tomee-api.version>
+        <tomee.version>${tomee10.version}</tomee.version>
+        <tomee-api.version>10.0-SNAPSHOT</tomee-api.version>
 
         <openejb.owb.version>${owb.version}</openejb.owb.version>
 


### PR DESCRIPTION
TomEE dependencies moved to TomEE-API 10.0-M2, TomEE 10.0-SNAPSHOT
successfully executed build profiles: Weld, OWB:
```
mvn -Drat.skip clean install -P Weld
mvn -Drat.skip clean install -P OWB
```
Please note: I was not able to resolve implementation of [NamingConventionAwareMetadataFilter](https://github.com/shadogray/deltaspike/blob/master/deltaspike/examples/jse-examples/src/main/java/org/apache/deltaspike/example/metadata/NamingConventionAwareMetadataFilter.java) :-/
I kindly ask to repair!