### PR TITLE
Weld5 - add Dependent scope to @Repository, skip intermediate generic…

### DIFF
--- a/.github/workflows/ds-ci.yml
+++ b/.github/workflows/ds-ci.yml
@@ -48,16 +48,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 11
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/deltaspike/modules/data/api/src/main/java/org/apache/deltaspike/data/api/Repository.java
+++ b/deltaspike/modules/data/api/src/main/java/org/apache/deltaspike/data/api/Repository.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Target;
 
 import org.apache.deltaspike.partialbean.api.PartialBeanBinding;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Stereotype;
 
 /**
@@ -36,6 +37,7 @@ import jakarta.enterprise.inject.Stereotype;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Inherited
+@Dependent
 @PartialBeanBinding
 public @interface Repository
 {

--- a/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/RepositoryExtension.java
+++ b/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/RepositoryExtension.java
@@ -90,6 +90,11 @@ public class RepositoryExtension implements Extension, Deactivatable
                 LOG.log(Level.FINER, "Class {0} is Deactivated", repositoryClass);
                 return;
             }
+            if (repositoryClass.getDeclaredAnnotation(Repository.class) == null)
+            {
+                LOG.log(Level.FINER, "Class {0} not annotated Repository", repositoryClass);
+                return;
+            }
 
             repositoryClasses.add(repositoryClass);
             REPOSITORY_CLASSES.add(repositoryClass);

--- a/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/meta/EntityMetadataInitializer.java
+++ b/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/meta/EntityMetadataInitializer.java
@@ -35,6 +35,10 @@ public class EntityMetadataInitializer
     public EntityMetadata init(RepositoryMetadata metadata)
     {
         EntityMetadata entityMetadata = extract(metadata.getRepositoryClass());
+        if (entityMetadata == null)
+        {
+            return null;
+        }
         
         entityMetadata.setPrimaryKeyProperty(EntityUtils.primaryKeyProperty(entityMetadata.getEntityClass()));
         entityMetadata.setVersionProperty(EntityUtils.getVersionProperty(entityMetadata.getEntityClass()));
@@ -45,6 +49,10 @@ public class EntityMetadataInitializer
     
     private EntityMetadata extract(Class<?> repositoryClass)
     {
+        if (!repositoryClass.isAnnotationPresent(Repository.class)) 
+        {
+            return null;
+        }
         // get from annotation
         Repository repository = repositoryClass.getAnnotation(Repository.class);
         Class<?> entityClass = repository.forEntity();

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/handler/EntityRepositoryHandlerTest.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/handler/EntityRepositoryHandlerTest.java
@@ -26,6 +26,7 @@ import org.apache.deltaspike.data.test.domain.Simple_;
 import org.apache.deltaspike.data.test.service.ExtendedRepositoryAbstract;
 import org.apache.deltaspike.data.test.service.ExtendedRepositoryAbstract2;
 import org.apache.deltaspike.data.test.service.ExtendedRepositoryAbstract4;
+import org.apache.deltaspike.data.test.service.ExtendedRepositoryAbstractSomeInterface;
 import org.apache.deltaspike.data.test.service.ExtendedRepositoryInterface;
 import org.apache.deltaspike.data.test.service.SimpleIntermediateRepository;
 import org.apache.deltaspike.data.test.service.SimpleStringIdRepository;
@@ -58,6 +59,7 @@ public class EntityRepositoryHandlerTest extends TransactionalTestCase
                 .addClasses(ExtendedRepositoryAbstract.class)
                 .addClasses(ExtendedRepositoryAbstract2.class)
                 .addClasses(ExtendedRepositoryAbstract4.class)
+                .addClasses(ExtendedRepositoryAbstractSomeInterface.class)
                 .addClasses(SimpleStringIdRepository.class, SimpleIntermediateRepository.class)
                 .addPackage(Simple.class.getPackage());
     }
@@ -73,6 +75,9 @@ public class EntityRepositoryHandlerTest extends TransactionalTestCase
 
     @Inject
     private ExtendedRepositoryAbstract4 repoAbstract4;
+    
+    @Inject
+    private ExtendedRepositoryAbstractSomeInterface repoAbstractRepo;
 
     @Inject
     private SimpleStringIdRepository stringIdRepo;
@@ -431,6 +436,14 @@ public class EntityRepositoryHandlerTest extends TransactionalTestCase
 
         assertEquals("Simple", entityName);
         assertEquals("EntitySimple4", entityName2);
+    }
+
+    @Test
+    public void abstract_should_return_entity_name()
+    {
+        final String entityName = repoAbstractRepo.getEntityName();
+
+        assertEquals("Simple", entityName);
     }
 
     @Test

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/domain/Simple5.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/domain/Simple5.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.deltaspike.data.test.domain;
+
+import jakarta.persistence.Entity;
+
+@Entity(name = "EntitySimple5")
+public class Simple5 extends SimpleBase {
+
+}

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/domain/SimpleBase.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/domain/SimpleBase.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.deltaspike.data.test.domain;
+
+public class SimpleBase {
+
+}

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/service/ExtendedRepositoryAbstractSomeInterface.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/service/ExtendedRepositoryAbstractSomeInterface.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.deltaspike.data.test.service;
+
+import org.apache.deltaspike.data.api.Repository;
+import org.apache.deltaspike.data.test.domain.Simple5;
+
+@Repository
+public abstract class ExtendedRepositoryAbstractSomeInterface
+        extends ExtendedRepositoryAbstractSomeInterfaceBase<Simple5, Long>
+{
+}

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/service/ExtendedRepositoryAbstractSomeInterfaceBase.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/service/ExtendedRepositoryAbstractSomeInterfaceBase.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.deltaspike.data.test.service;
+
+import java.io.Serializable;
+
+import org.apache.deltaspike.data.api.AbstractEntityRepository;
+import org.apache.deltaspike.data.test.domain.Simple4;
+import org.apache.deltaspike.data.test.domain.SimpleBase;
+
+public abstract class ExtendedRepositoryAbstractSomeInterfaceBase<E extends SimpleBase, PK extends Serializable> 
+    extends AbstractEntityRepository<E, PK> implements SomeInterface<E> 
+{
+    public String getEntityName()
+    {
+        return entityName();
+    }
+    
+    @Override
+    public void someMethod() 
+    {
+    }
+}

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/service/SomeInterface.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/service/SomeInterface.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.deltaspike.data.test.service;
+
+import org.apache.deltaspike.data.test.domain.SimpleBase;
+
+/**
+ * Some interface that a repository may implement additionally
+ */
+public interface SomeInterface<E extends SimpleBase> {
+
+	void someMethod();
+	
+}


### PR DESCRIPTION
## Weld5 (Wildfly-31) - Deltaspike fails on Detection of Scope 
```
Caused by: java.lang.NullPointerException: Cannot invoke "java.lang.annotation.Annotation.annotationType()" because the return value of "java.util.Iterator.next()" is null
        at org.jboss.weld.core@5.1.2.Final//org.jboss.weld.bootstrap.events.configurator.BeanAttributesConfiguratorImpl.initScope(BeanAttributesConfiguratorImpl.java:252)
        at org.jboss.weld.core@5.1.2.Final//org.jboss.weld.bootstrap.events.configurator.BeanAttributesConfiguratorImpl.complete(BeanAttributesConfiguratorImpl.java:227)
        at org.jboss.weld.core@5.1.2.Final//org.jboss.weld.bootstrap.events.configurator.BeanConfiguratorImpl$ImmutableBean.<init>(BeanConfiguratorImpl.java:498)
        at org.jboss.weld.core@5.1.2.Final//org.jboss.weld.bootstrap.events.configurator.BeanConfiguratorImpl.complete(BeanConfiguratorImpl.java:333)
        at org.jboss.weld.core@5.1.2.Final//org.jboss.weld.bootstrap.events.AfterBeanDiscoveryImpl$BeanRegistration.initBean(AfterBeanDiscoveryImpl.java:337)
```

## Intermediate generic(!) Repository implementations are not correctly identitfied by MetadataInitializer
A structure of:
 AppEntityRepository<Entity, Long> extends AbstractAppEntityRepository<E extends BaseEntity, 
S extends Serializable> extends AbstractEntityRepository<E,S>  
will lead to:
```
Caused by: java.lang.ClassCastException: class sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl cannot be cast to class java.lang.Class (sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl and java.lang.Class are in module java.base of loader 'bootstrap')
        at deployment.archive-web.war//org.apache.deltaspike.data.impl.meta.EntityMetadataInitializer.extract(EntityMetadataInitializer.java:82)
        at deployment.archive-web.war//org.apache.deltaspike.data.impl.meta.EntityMetadataInitializer.extract(EntityMetadataInitializer.java:90)
        at deployment.archive-web.war//org.apache.deltaspike.data.impl.meta.EntityMetadataInitializer.init(EntityMetadataInitializer.java:37)
        at deployment.archive-web.war//org.apache.deltaspike.data.impl.meta.EntityMetadataInitializer$Proxy$_$$_WeldClientProxy.init(Unknown Source)
        at deployment.archive-web.war//org.apache.deltaspike.data.impl.meta.RepositoryMetadataInitializer.init(RepositoryMetadataInitializer.java:83)
        at deployment.archive-web.war//org.apache.deltaspike.data.impl.meta.RepositoryMetadataInitializer$Proxy$_$$_WeldClientProxy.init(Unknown Source)
        at deployment.archive-web.war//org.apache.deltaspike.data.impl.meta.RepositoryMetadataHandler.init(RepositoryMetadataHandler.java:50)
```
