### PR TITLE
Arquillian.protocol to jakarta,6.0 - TestCase for Failure on generic …

### DIFF
--- a/deltaspike/modules/data/api/src/main/java/org/apache/deltaspike/data/api/Repository.java
+++ b/deltaspike/modules/data/api/src/main/java/org/apache/deltaspike/data/api/Repository.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Target;
 
 import org.apache.deltaspike.partialbean.api.PartialBeanBinding;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Stereotype;
 
 /**
@@ -36,6 +37,7 @@ import jakarta.enterprise.inject.Stereotype;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Inherited
+@Dependent
 @PartialBeanBinding
 public @interface Repository
 {

--- a/deltaspike/modules/data/impl/pom.xml
+++ b/deltaspike/modules/data/impl/pom.xml
@@ -49,6 +49,38 @@
         </deltaspike.osgi.provide.capability>
     </properties>
 
+    <dependencyManagement>
+		<!-- needed for arquillian dependency resolution: (@see TestDeployments#getDeltaSpikeDataWithDependencies) -->
+		<dependencies>
+			<dependency>
+	            <groupId>org.apache.deltaspike.core</groupId>
+	            <artifactId>deltaspike-core-api</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.deltaspike.modules</groupId>
+				<artifactId>deltaspike-partial-bean-module-api</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.deltaspike.modules</groupId>
+				<artifactId>deltaspike-jpa-module-api</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.deltaspike.modules</groupId>
+				<artifactId>deltaspike-data-module-api</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.deltaspike.modules</groupId>
+				<artifactId>deltaspike-data-module-impl</artifactId>
+				<version>${project.version}</version>
+				<scope>runtime</scope>
+			</dependency>
+		</dependencies>				
+	</dependencyManagement>
+
     <build>
         <pluginManagement>
             <plugins>
@@ -93,7 +125,6 @@
     </build>
 
     <dependencies>
-
         <dependency>
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/handler/EntityRepositoryHandlerInheritedTest.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/handler/EntityRepositoryHandlerInheritedTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.deltaspike.data.impl.handler;
+
+import static org.apache.deltaspike.data.test.util.TestDeployments.initDeployment;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.apache.deltaspike.data.test.TransactionalTestCase;
+import org.apache.deltaspike.data.test.domain.Simple;
+import org.apache.deltaspike.data.test.domain.Simple5;
+import org.apache.deltaspike.data.test.service.ExtendedRepositoryAbstractInherited;
+import org.apache.deltaspike.data.test.service.ExtendedRepositoryAbstractIntermediate;
+import org.apache.deltaspike.test.category.WebProfileCategory;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import jakarta.inject.Inject;
+
+@Category(WebProfileCategory.class)
+public class EntityRepositoryHandlerInheritedTest extends TransactionalTestCase
+{
+    
+    private static final Asset beansXml = new StringAsset("<beans bean-discovery-mode=\"all\"/>");
+
+    @Deployment
+    public static Archive<?> deployment()
+    {
+        return initDeployment(true, beansXml)
+                .addClasses(ExtendedRepositoryAbstractIntermediate.class, 
+                        ExtendedRepositoryAbstractInherited.class,
+                        NamedQualifiedEntityManagerTestProducer.class)
+                .addPackage(Simple.class.getPackage());
+    }
+
+    @Inject
+    private ExtendedRepositoryAbstractInherited repo;
+
+    @Test
+    public void should_return_entity_name()
+    {
+        final String entityName = repo.getEntityName();
+
+        assertEquals("EntitySimple5", entityName);
+    }
+
+    @Test
+    public void should_return_null_entity()
+    {
+        final Simple5 entity = repo.findByIdAndName(-1L, "any");
+
+        assertNull(entity);
+    }
+
+}

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/handler/EntityRepositoryHandlerTest.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/handler/EntityRepositoryHandlerTest.java
@@ -18,6 +18,15 @@
  */
 package org.apache.deltaspike.data.impl.handler;
 
+import static org.apache.deltaspike.data.test.util.TestDeployments.initDeployment;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.List;
+import java.util.Optional;
+
 import org.apache.deltaspike.data.test.TransactionalTestCase;
 import org.apache.deltaspike.data.test.domain.Simple;
 import org.apache.deltaspike.data.test.domain.Simple2;
@@ -37,14 +46,6 @@ import org.junit.experimental.categories.Category;
 
 import jakarta.inject.Inject;
 import jakarta.persistence.metamodel.SingularAttribute;
-import java.util.List;
-import java.util.Optional;
-
-import static org.apache.deltaspike.data.test.util.TestDeployments.initDeployment;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 @Category(WebProfileCategory.class)
 public class EntityRepositoryHandlerTest extends TransactionalTestCase
@@ -73,7 +74,7 @@ public class EntityRepositoryHandlerTest extends TransactionalTestCase
 
     @Inject
     private ExtendedRepositoryAbstract4 repoAbstract4;
-
+    
     @Inject
     private SimpleStringIdRepository stringIdRepo;
 

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/handler/NamedQualifiedEntityManagerTestProducer.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/handler/NamedQualifiedEntityManagerTestProducer.java
@@ -18,17 +18,19 @@
  */
 package org.apache.deltaspike.data.impl.handler;
 
-import jakarta.enterprise.inject.Default;
+import org.apache.deltaspike.data.test.util.EntityManagerProducer;
+
 import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.Specializes;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 
-@Default
-public class NonQualifiedEntityManagerTestProducer
+@Specializes
+public class NamedQualifiedEntityManagerTestProducer extends EntityManagerProducer
 {
 
     @Produces
-    @PersistenceContext
+    @PersistenceContext(unitName = "test")
     private EntityManager entityManager;
 
 }

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/domain/Parent.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/domain/Parent.java
@@ -22,6 +22,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 
 @Entity
@@ -34,6 +35,7 @@ public class Parent extends NamedEntity
     @jakarta.persistence.OneToMany(cascade = CascadeType.ALL, targetEntity = OneToMany.class)
     private List<OneToMany> many = new LinkedList<OneToMany>();
 
+    @Column(name = "p_value")
     private Long value = Long.valueOf(0);
 
     public Parent()

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/domain/Simple5.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/domain/Simple5.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.deltaspike.data.test.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+@Entity(name = "EntitySimple5")
+public class Simple5 extends SimpleBase
+{
+
+}

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/domain/SimpleBase.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/domain/SimpleBase.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.deltaspike.data.test.domain;
+
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+
+@MappedSuperclass
+public class SimpleBase
+{
+
+    @GeneratedValue
+    @Id
+    private long id;
+
+    private String name;
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public void setName(String name)
+    {
+        this.name = name;
+    }
+
+    public long getId()
+    {
+        return id;
+    }
+
+}

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/service/ExtendedRepositoryAbstractInherited.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/service/ExtendedRepositoryAbstractInherited.java
@@ -16,19 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.deltaspike.data.impl.handler;
+package org.apache.deltaspike.data.test.service;
 
-import jakarta.enterprise.inject.Default;
-import jakarta.enterprise.inject.Produces;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
+import org.apache.deltaspike.data.api.Repository;
+import org.apache.deltaspike.data.test.domain.Simple5;
 
-@Default
-public class NonQualifiedEntityManagerTestProducer
+@Repository
+public abstract class ExtendedRepositoryAbstractInherited 
+    extends ExtendedRepositoryAbstractIntermediate<Simple5, Long>
 {
-
-    @Produces
-    @PersistenceContext
-    private EntityManager entityManager;
-
+    
 }

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/service/ExtendedRepositoryAbstractIntermediate.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/service/ExtendedRepositoryAbstractIntermediate.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.deltaspike.data.test.service;
+
+import java.io.Serializable;
+
+import org.apache.deltaspike.data.api.AbstractEntityRepository;
+import org.apache.deltaspike.data.api.Query;
+import org.apache.deltaspike.data.api.Repository;
+import org.apache.deltaspike.data.api.SingleResultType;
+import org.apache.deltaspike.data.test.domain.Simple;
+import org.apache.deltaspike.data.test.domain.SimpleBase;
+
+@Repository
+public abstract class ExtendedRepositoryAbstractIntermediate<E extends SimpleBase, PK extends Serializable>
+        extends AbstractEntityRepository<E, PK>
+{
+    public String getTableName()
+    {
+        return tableName();
+    }
+
+    public String getEntityName()
+    {
+        return entityName();
+    }
+    
+    @Query(singleResult = SingleResultType.OPTIONAL)
+    public abstract E findByIdAndName(Long id, String name);
+
+}

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/util/TestDeployments.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/util/TestDeployments.java
@@ -25,6 +25,7 @@ import org.apache.deltaspike.data.test.TransactionalTestCase;
 import org.apache.deltaspike.data.test.domain.AuditedEntity;
 import org.jboss.arquillian.container.test.spi.TestDeployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
@@ -49,6 +50,11 @@ public abstract class TestDeployments {
 
     public static WebArchive initDeployment(boolean addDefaultEntityManagerProducer)
     {
+        return initDeployment(addDefaultEntityManagerProducer, EmptyAsset.INSTANCE);
+    }
+    
+    public static WebArchive initDeployment(boolean addDefaultEntityManagerProducer, Asset beansXmlAsset)
+    {
         Logging.reconfigure();
 
         WebArchive archive = ShrinkWrap
@@ -58,7 +64,7 @@ public abstract class TestDeployments {
                 .addPackages(true, AuditedEntity.class.getPackage())
                 .addAsLibraries(getDeltaSpikeDataWithDependencies())
                 .addAsWebInfResource("test-persistence.xml", "classes/META-INF/persistence.xml")
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsWebInfResource(beansXmlAsset, "beans.xml")
                 .addAsWebInfResource(new StringAsset(DS_PROPERTIES_WITH_ENV_AWARE_TX_STRATEGY),
                         "classes/META-INF/apache-deltaspike.properties");
 

--- a/deltaspike/parent/code/pom.xml
+++ b/deltaspike/parent/code/pom.xml
@@ -617,7 +617,7 @@
                 </dependency>
                 <dependency>
                     <groupId>org.jboss.arquillian.protocol</groupId>
-                    <artifactId>arquillian-protocol-servlet</artifactId>
+                    <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
                     <scope>test</scope>
                 </dependency>
 
@@ -676,12 +676,6 @@
                     <groupId>org.jboss.weld</groupId>
                     <artifactId>weld-core-impl</artifactId>
                     <version>${weld.version}</version>
-                    <scope>provided</scope>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.inject</groupId>
-                    <artifactId>jakarta.inject</artifactId>
-                    <version>1</version>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>

--- a/deltaspike/test-utils/src/main/resources/arquillian-jboss.xml
+++ b/deltaspike/test-utils/src/main/resources/arquillian-jboss.xml
@@ -28,7 +28,7 @@
     -->
 
     <!-- We need to specify this because the default protocol for AS7 and Wildfly doesn't work very well -->
-    <defaultProtocol type="Servlet 3.0" />
+    <defaultProtocol type="Servlet 6.0" />
 
     <container qualifier="jbossas-managed-7">
         <configuration>
@@ -41,6 +41,7 @@
     
     <container qualifier="wildfly-managed">
         <configuration>
+            <!-- for debugging add: -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y  -->
             <property name="javaVmArguments">-client -noverify -Xms64m -Xmx1024m -XX:MaxPermSize=512m -Dcdicontainer.version=${cdicontainer.version} ${jacoco.agent}</property>
             <property name="outputToConsole">false</property>
             <property name="allowConnectingToRunningServer">true</property>


### PR DESCRIPTION
### Arquillian
move to protocol-servlet-jakarta, type: Servlet 6.0
wildfly-managed arquillian test available again

### Repository: add Dependent scope
```
 Caused by: java.lang.NullPointerException: Cannot invoke "java.lang.annotation.Annotation.annotationType()" because the return value of "java.util.Iterator.next()" is null
           at [org.jboss.weld.core@5.1.2.](mailto:org.jboss.weld.core@5.1.2.)Final//org.jboss.weld.bootstrap.events.configurator.BeanAttributesConfiguratorImpl.initScope(BeanAttributesConfiguratorImpl.java:252)
           at [org.jboss.weld.core@5.1.2.](mailto:org.jboss.weld.core@5.1.2.)Final//org.jboss.weld.bootstrap.events.configurator.BeanAttributesConfiguratorImpl.complete(BeanAttributesConfiguratorImpl.java:227)
           at [org.jboss.weld.core@5.1.2.](mailto:org.jboss.weld.core@5.1.2.)Final//org.jboss.weld.bootstrap.events.configurator.BeanConfiguratorImpl$ImmutableBean.<init>(BeanConfiguratorImpl.java:498)
           at [org.jboss.weld.core@5.1.2.](mailto:org.jboss.weld.core@5.1.2.)Final//org.jboss.weld.bootstrap.events.configurator.BeanConfiguratorImpl.complete(BeanConfiguratorImpl.java:333)
           at [org.jboss.weld.core@5.1.2.](mailto:org.jboss.weld.core@5.1.2.)Final//org.jboss.weld.bootstrap.events.AfterBeanDiscoveryImpl$BeanRegistration.initBean(AfterBeanDiscoveryImpl.java:337)
```

### TestCase for Failure of inherited abstract generic(!) Repository classes
Usage: 
```
export JBOSS_HOME=<jbossHome>
mvn -Drat.skip clean install -pl deltaspike/modules/data/impl/ -Pwildfly-managed -Dtest=EntityRepositoryHandlerInheritedTest
```
Result:
```
Caused by: java.lang.ClassCastException: class sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl cannot be cast to class java.lang.Class (sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl and java.lang.Class are in module java.base of loader 'bootstrap')
        at deployment.test.war//org.apache.deltaspike.data.impl.meta.EntityMetadataInitializer.extract(EntityMetadataInitializer.java:82)
        at deployment.test.war//org.apache.deltaspike.data.impl.meta.EntityMetadataInitializer.extract(EntityMetadataInitializer.java:90)
        at deployment.test.war//org.apache.deltaspike.data.impl.meta.EntityMetadataInitializer.init(EntityMetadataInitializer.java:37)
        at deployment.test.war//org.apache.deltaspike.data.impl.meta.EntityMetadataInitializer$Proxy$_$$_WeldClientProxy.init(Unknown Source)
        at deployment.test.war//org.apache.deltaspike.data.impl.meta.RepositoryMetadataInitializer.init(RepositoryMetadataInitializer.java:83)
        at deployment.test.war//org.apache.deltaspike.data.impl.meta.RepositoryMetadataInitializer$Proxy$_$$_WeldClientProxy.init(Unknown Source)
        at deployment.test.war//org.apache.deltaspike.data.impl.meta.RepositoryMetadataHandler.init(RepositoryMetadataHandler.java:50)
```
