### PR TITLE
Wildfly-31 wildfly-build-managed - BeansXmlUtil.discovery-mode=all - mostly working

### DIFF
--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/config/injectable/InjectableConfigPropertyTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/config/injectable/InjectableConfigPropertyTest.java
@@ -34,7 +34,6 @@ import org.apache.deltaspike.test.util.FileUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
@@ -46,6 +45,7 @@ import org.apache.deltaspike.test.core.api.config.injectable.numberconfig.Number
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -69,12 +69,12 @@ public class InjectableConfigPropertyTest
                 .addPackage(ServerEndpointPojoWithCt.class.getPackage())
                 .addPackage(NumberConfiguredBean.class.getPackage())
                 .addAsManifestResource(FileUtils.getFileForURL(fileUrl.toString()))
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap.create(WebArchive.class, "beanProvider.war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addAsLibraries(testJar)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
     @ConfigProperty(name = "myapp.some.server", cacheFor = 2, cacheUnit = TimeUnit.SECONDS)

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/config/propertyconfigsource/ConfigPropertyWARTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/config/propertyconfigsource/ConfigPropertyWARTest.java
@@ -24,11 +24,12 @@ import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 @Category(WebProfileCategory.class)
@@ -45,7 +46,7 @@ public class ConfigPropertyWARTest extends BaseTestConfigProperty
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addPackage(ConfigPropertyWARTest.class.getPackage())
                 .addAsResource(CONFIG_FILE_NAME)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml")
                 .addAsWebInfResource(new StringAsset(PROPERTIES),
                         "classes/META-INF/apache-deltaspike.properties");
 

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/config/propertyconfigsource/FileConfigSourceTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/config/propertyconfigsource/FileConfigSourceTest.java
@@ -29,13 +29,14 @@ import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 /**
  * Test for picking up a file system based config
@@ -49,12 +50,12 @@ public class FileConfigSourceTest
     {
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "FileConfigSourceTest.jar")
             .addClasses(FileConfigSourceTest.class, FileSystemConfig.class)
-            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+            .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap.create(WebArchive.class, "beanProvider.war")
             .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
             .addAsLibraries(testJar)
-            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+            .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
 

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/config/propertyconfigsource/PropertyConfigSourceTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/config/propertyconfigsource/PropertyConfigSourceTest.java
@@ -24,13 +24,14 @@ import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 @Category(SeCategory.class) //X TODO this is only SeCategory as there is currently an Arq problem with properties!
@@ -51,12 +52,12 @@ public class PropertyConfigSourceTest
                 .addAsResource(CONFIG_FILE_NAME)
                 .addAsResource(BOOTCONFIG_FILE_NAME)
                 .addAsResource(NOT_PICKED_UP_CONFIG_FILE_NAME)
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap.create(WebArchive.class, "beanProvider.war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addAsLibraries(testJar)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
 

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/exclude/ExcludeTestProjectStageWarFileDevelopment.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/exclude/ExcludeTestProjectStageWarFileDevelopment.java
@@ -25,13 +25,13 @@ import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.runner.RunWith;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 /**
  * Tests for {@link org.apache.deltaspike.core.api.exclude.Exclude}
@@ -53,14 +53,14 @@ public class ExcludeTestProjectStageWarFileDevelopment extends ExcludeTestProjec
 
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "excludeTestProjectStageDevelopmentTest.jar")
                 .addPackage(ExcludeTestProjectStageWarFileDevelopment.class.getPackage())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml")
                 .addAsResource(new StringAsset("org.apache.deltaspike.ProjectStage = Development"),
                     "apache-deltaspike.properties"); // when deployed on some remote container
 
         return ShrinkWrap.create(WebArchive.class, archiveName + ".war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addAsLibraries(testJar)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
     @AfterClass

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/exclude/ExcludeWarFileTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/exclude/ExcludeWarFileTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.deltaspike.test.core.api.exclude;
 
+import jakarta.enterprise.inject.spi.Extension;
 import org.apache.deltaspike.core.api.projectstage.ProjectStage;
 import org.apache.deltaspike.core.impl.exclude.extension.ExcludeExtension;
 import org.apache.deltaspike.core.util.ProjectStageProducer;
@@ -27,18 +28,18 @@ import org.apache.deltaspike.test.util.FileUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 
-import jakarta.enterprise.inject.spi.Extension;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 /**
  * Tests for {@link org.apache.deltaspike.core.api.exclude.Exclude}
@@ -63,12 +64,12 @@ public class ExcludeWarFileTest extends ExcludeTest
                 .addPackage(TestClassDeactivator.class.getPackage())
                 .addAsManifestResource(new StringAsset(getConfigContent()),
                     "apache-deltaspike.properties") // when deployed on some remote container;
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap.create(WebArchive.class, archiveName + ".war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addAsLibraries(testJar)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml")
                 .addAsServiceProvider(Extension.class, ExcludeExtension.class);
     }
 

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/exclude/uc001/EntityExcludeTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/exclude/uc001/EntityExcludeTest.java
@@ -25,7 +25,6 @@ import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -33,6 +32,8 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 public class EntityExcludeTest
@@ -48,14 +49,14 @@ public class EntityExcludeTest
 
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, archiveName + ".jar")
                 .addPackage(EntityExcludeTest.class.getPackage())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml")
                 .addAsResource(new StringAsset("org.apache.deltaspike.ProjectStage = Development"),
                     "apache-deltaspike.properties"); // when deployed on some remote container;
 
         return ShrinkWrap.create(WebArchive.class, archiveName + ".war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addAsLibraries(testJar)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
     @AfterClass

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/message/MessageContextTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/message/MessageContextTest.java
@@ -33,7 +33,6 @@ import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
@@ -41,6 +40,8 @@ import org.junit.Assume;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 /**
  * Tests for {@link MessageContext}
@@ -66,13 +67,13 @@ public class MessageContextTest
         final JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "messageContextTest.jar")
                 .addPackage(MessageContextTest.class.getPackage())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap
                 .create(WebArchive.class, "messageContextTest.war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addAsLibraries(testJar)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml")
                 .addAsServiceProvider(Extension.class,
                         MessageBundleExtension.class);
     }

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/message/MessageFormattedMessageTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/message/MessageFormattedMessageTest.java
@@ -29,7 +29,6 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.Asset;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -37,6 +36,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -72,7 +72,7 @@ public class MessageFormattedMessageTest
                 .create(WebArchive.class, "messageFormattedMessageTest.war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addAsLibraries(testJar)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml")
                 .addAsServiceProvider(Extension.class,
                         MessageBundleExtension.class);
     }

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/message/MessageTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/message/MessageTest.java
@@ -24,7 +24,6 @@ import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
@@ -34,6 +33,7 @@ import org.junit.runner.RunWith;
 import jakarta.enterprise.inject.spi.Extension;
 import jakarta.inject.Inject;
 
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -57,13 +57,13 @@ public class MessageTest
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "messageTest.jar")
                 .addPackage(MessageTest.class.getPackage())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap
                 .create(WebArchive.class, "messageTest.war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addAsLibraries(testJar)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml")
                 .addAsServiceProvider(Extension.class,
                         MessageBundleExtension.class);
     }

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/message/MinimalMessagesTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/message/MinimalMessagesTest.java
@@ -25,7 +25,6 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Filters;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
@@ -34,6 +33,8 @@ import org.junit.runner.RunWith;
 
 import jakarta.enterprise.inject.spi.Extension;
 import jakarta.inject.Inject;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 /**
  * Tests for type-safe messages without {@link org.apache.deltaspike.core.api.message.MessageTemplate}
@@ -61,7 +62,7 @@ public class MinimalMessagesTest
                 .create(JavaArchive.class, "minimalMessageTest.jar")
                 .addPackages(false, Filters.exclude(MessageContextTest.class),
                         MinimalMessagesTest.class.getPackage())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap
                 .create(WebArchive.class, "minimalMessageTest.war")
@@ -69,7 +70,7 @@ public class MinimalMessagesTest
                 .addAsLibraries(testJar)
                 .addAsResource("customMinimalMessage_en.properties")
                 .addAsResource("org/apache/deltaspike/test/core/api/message/MinimalMessages_en.properties")
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml")
                 .addAsServiceProvider(Extension.class,
                         MessageBundleExtension.class);
     }

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/message/SimpleMessageTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/message/SimpleMessageTest.java
@@ -26,7 +26,6 @@ import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
@@ -36,6 +35,7 @@ import org.junit.runner.RunWith;
 import jakarta.enterprise.inject.spi.Extension;
 import jakarta.inject.Inject;
 
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -66,13 +66,13 @@ public class SimpleMessageTest
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "simpleMessageTest.jar")
                 .addPackage(SimpleMessageTest.class.getPackage())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap
                 .create(WebArchive.class, "simpleMessageTest.war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addAsLibraries(testJar)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml")
                 .addAsServiceProvider(Extension.class,
                         MessageBundleExtension.class);
     }

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/message/broken/BrokenMessageBundleOnClassTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/message/broken/BrokenMessageBundleOnClassTest.java
@@ -28,13 +28,13 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 //X import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.experimental.categories.Category;
 //X import org.junit.Test;
 //X import org.junit.runner.RunWith;
 
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -64,13 +64,13 @@ public class BrokenMessageBundleOnClassTest
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "invalidMessageBundleTest.jar")
                 .addPackage(BrokenMessageBundleClass.class.getPackage())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap
                 .create(WebArchive.class, "invalidMessageBundleTest.war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addAsLibraries(testJar)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml")
                 .addAsServiceProvider(Extension.class,
                         MessageBundleExtension.class);
     }

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/message/locale/ConfigurableLocaleMessageTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/message/locale/ConfigurableLocaleMessageTest.java
@@ -30,7 +30,6 @@ import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -38,6 +37,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -48,7 +48,7 @@ import static org.junit.Assert.assertEquals;
 public class ConfigurableLocaleMessageTest
 {
     private static final String BEANS_XML_CONTENT =
-            "<beans><alternatives><class>" +
+            "<beans bean-discovery-mode=\"all\"><alternatives><class>" +
             ConfigurableLocaleResolver.class.getName() +
             "</class></alternatives></beans>";
 
@@ -72,7 +72,7 @@ public class ConfigurableLocaleMessageTest
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "localeMessageTest.jar")
                 .addPackage(ConfigurableLocaleMessageTest.class.getPackage())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap
                 .create(WebArchive.class, "localeMessageTest.war")

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/provider/BeanManagerProviderWarFileTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/provider/BeanManagerProviderWarFileTest.java
@@ -22,9 +22,10 @@ import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.runner.RunWith;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 public class BeanManagerProviderWarFileTest extends BeanManagerProviderTest
@@ -41,6 +42,6 @@ public class BeanManagerProviderWarFileTest extends BeanManagerProviderTest
         return ShrinkWrap.create(WebArchive.class, archiveName + ".war")
                 .addPackage(BeanManagerProviderWarFileTest.class.getPackage())
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 }

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/provider/BeanProviderTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/provider/BeanProviderTest.java
@@ -27,7 +27,6 @@ import org.apache.deltaspike.test.utils.Serializer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
@@ -37,6 +36,8 @@ import org.junit.runner.RunWith;
 
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 public class BeanProviderTest
@@ -53,12 +54,12 @@ public class BeanProviderTest
     {
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "beanProviderTest.jar")
                 .addPackage(BeanProviderTest.class.getPackage())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap.create(WebArchive.class, "beanProvider.war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addAsLibraries(testJar)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
     /**

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/scope/conversation/grouped/explicit/ExplicitlyGroupedConversationsTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/scope/conversation/grouped/explicit/ExplicitlyGroupedConversationsTest.java
@@ -26,7 +26,6 @@ import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
@@ -36,6 +35,8 @@ import org.junit.runner.RunWith;
 
 import jakarta.enterprise.context.ContextNotActiveException;
 import jakarta.inject.Inject;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 @Category(SeCategory.class)
@@ -49,12 +50,12 @@ public class ExplicitlyGroupedConversationsTest
 
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, archiveName + ".jar")
                 .addPackage(ExplicitlyGroupedConversationsTest.class.getPackage().getName())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap.create(WebArchive.class, archiveName + ".war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addAsLibraries(testJar)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
     @Inject

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/scope/conversation/grouped/implicit/ImplicitlyGroupedConversationsTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/scope/conversation/grouped/implicit/ImplicitlyGroupedConversationsTest.java
@@ -25,7 +25,6 @@ import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
@@ -35,6 +34,8 @@ import org.junit.runner.RunWith;
 
 import jakarta.enterprise.context.ContextNotActiveException;
 import jakarta.inject.Inject;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 @Category(SeCategory.class)
@@ -48,12 +49,12 @@ public class ImplicitlyGroupedConversationsTest
 
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, archiveName + ".jar")
                 .addPackage(ImplicitlyGroupedConversationsTest.class.getPackage().getName())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap.create(WebArchive.class, archiveName + ".war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addAsLibraries(testJar)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
     @Inject

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/scope/conversation/subgroup/uc001/GroupedConversationSubGroupTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/scope/conversation/subgroup/uc001/GroupedConversationSubGroupTest.java
@@ -27,7 +27,6 @@ import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
@@ -36,6 +35,8 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import jakarta.inject.Inject;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 @Category(SeCategory.class)
@@ -50,12 +51,12 @@ public class GroupedConversationSubGroupTest
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, archiveName + ".jar")
                 .addPackage(GroupedConversationSubGroupTest.class.getPackage())
                 .addPackage(TestBaseBean.class.getPackage())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap.create(WebArchive.class, archiveName + ".war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addAsLibraries(testJar)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
     @Inject

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/scope/conversation/subgroup/uc002/GroupedConversationSubGroupTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/scope/conversation/subgroup/uc002/GroupedConversationSubGroupTest.java
@@ -31,7 +31,6 @@ import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
@@ -40,6 +39,8 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import jakarta.inject.Inject;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 @Category(SeCategory.class)
@@ -54,12 +55,12 @@ public class GroupedConversationSubGroupTest
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, archiveName + ".jar")
                 .addPackage(GroupedConversationSubGroupTest.class.getPackage())
                 .addPackage(TestBaseBean.class.getPackage())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap.create(WebArchive.class, archiveName + ".war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addAsLibraries(testJar)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
     @Inject

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/scope/conversation/subgroup/uc003/GroupedConversationSubGroupTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/scope/conversation/subgroup/uc003/GroupedConversationSubGroupTest.java
@@ -28,7 +28,6 @@ import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
@@ -37,6 +36,8 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import jakarta.inject.Inject;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 @Category(SeCategory.class)
@@ -51,12 +52,12 @@ public class GroupedConversationSubGroupTest
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, archiveName + ".jar")
                 .addPackage(GroupedConversationSubGroupTest.class.getPackage())
                 .addPackage(TestBaseBean.class.getPackage())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap.create(WebArchive.class, archiveName + ".war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addAsLibraries(testJar)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
     @Inject

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/scope/viewaccess/ViewAccessScopedTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/scope/viewaccess/ViewAccessScopedTest.java
@@ -25,7 +25,6 @@ import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
@@ -34,6 +33,8 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import jakarta.inject.Inject;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 @Category(SeCategory.class)
@@ -47,12 +48,12 @@ public class ViewAccessScopedTest
 
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, archiveName + ".jar")
                 .addPackage(ViewAccessScopedTest.class.getPackage().getName())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap.create(WebArchive.class, archiveName + ".war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addAsLibraries(testJar)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
     @Inject

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/util/ProxyUtilsTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/util/ProxyUtilsTest.java
@@ -18,24 +18,24 @@
  */
 package org.apache.deltaspike.test.core.api.util;
 
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
-import java.util.List;
-
 import jakarta.inject.Inject;
-
 import org.apache.deltaspike.core.util.ProxyUtils;
 import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.List;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 public class ProxyUtilsTest
@@ -53,7 +53,7 @@ public class ProxyUtilsTest
         return ShrinkWrap
                 .create(WebArchive.class, "proxyUtil.war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml")
                 .addClasses(ProxyUtilsTest.class, MyBean.class, MyInterface.class,
                         MyInterfaceImpl.class);
     }

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/util/context/AbstractContextTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/api/util/context/AbstractContextTest.java
@@ -19,20 +19,20 @@
 package org.apache.deltaspike.test.core.api.util.context;
 
 import jakarta.enterprise.inject.spi.Extension;
-
 import org.apache.deltaspike.core.api.provider.BeanProvider;
 import org.apache.deltaspike.test.category.SeCategory;
 import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.junit.Test;
-import org.junit.Assert;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 /**
  * We test the AbstractContext by implementing a simple dummy context.
@@ -52,14 +52,14 @@ public class AbstractContextTest
                 .create(JavaArchive.class, "abstractContextTest.jar")
                 .addClass(AbstractContextTest.class)
                 .addClass(DummyBean.class)
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml")
                 .addAsServiceProvider(Extension.class, DummyScopeExtension.class);
 
         return ShrinkWrap
                 .create(WebArchive.class, "abstractContextTest.war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addAsLibraries(testJar)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
 

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/activation/ClassDeactivationWarFileTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/activation/ClassDeactivationWarFileTest.java
@@ -24,12 +24,13 @@ import org.apache.deltaspike.test.util.FileUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.runner.RunWith;
 
 import java.net.URL;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 public class ClassDeactivationWarFileTest extends ClassDeactivationTest
@@ -48,12 +49,12 @@ public class ClassDeactivationWarFileTest extends ClassDeactivationTest
 
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "testClassDeactivationTest.jar")
                 .addPackage(ClassDeactivationWarFileTest.class.getPackage())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap.create(WebArchive.class, archiveName + ".war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addAsLibraries(testJar)
                 .addAsResource(FileUtils.getFileForURL(fileUrl.toString()), DeltaSpikeTest.DELTASPIKE_PROPERTIES)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 }

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/activation/DefaultClassDeactivatorTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/activation/DefaultClassDeactivatorTest.java
@@ -25,13 +25,13 @@ import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 
@@ -54,13 +54,13 @@ public class DefaultClassDeactivatorTest extends ClassDeactivationTest
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "testClassDeactivationTest.jar")
                 .addPackage(ClassDeactivationWarFileTest.class.getPackage())
                 .addClass(DefaultClassDeactivator.class)
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap.create(WebArchive.class, archiveName + ".war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addAsLibraries(testJar)
                 .addAsResource(new StringAsset(dsPropsBuilder.toString()), DeltaSpikeTest.DELTASPIKE_PROPERTIES)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
     @Test

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/custom/spi/ServiceUtilsWarFileTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/custom/spi/ServiceUtilsWarFileTest.java
@@ -22,10 +22,11 @@ import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.runner.RunWith;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 public class ServiceUtilsWarFileTest extends ServiceUtilsTest
@@ -38,13 +39,13 @@ public class ServiceUtilsWarFileTest extends ServiceUtilsTest
 
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, archiveName + ".jar")
                 .addPackage(ServiceUtilsWarFileTest.class.getPackage())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap.create(WebArchive.class, archiveName + ".war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addAsLibraries(testJar)
                 //due to an issue with arquillian we can just add it to the web-archive (and not the jar)
                 .addAsServiceProvider(MyInterface.class, MyImpl.class)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 }

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/future/FutureableTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/future/FutureableTest.java
@@ -22,7 +22,6 @@ import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
@@ -35,6 +34,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -58,7 +58,7 @@ public class FutureableTest {
         return ShrinkWrap.create(WebArchive.class, "FutureableTest.war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addAsLibraries(testJar)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
     @Inject

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/future/ThreadPoolManagerTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/future/ThreadPoolManagerTest.java
@@ -25,7 +25,6 @@ import org.apache.deltaspike.core.spi.config.ConfigSource;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,6 +38,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
@@ -52,7 +52,7 @@ public class ThreadPoolManagerTest
     {
         return ShrinkWrap.create(WebArchive.class, "ThreadPoolManagerTest.war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
     @Inject

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/interdyn/InterDynTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/interdyn/InterDynTest.java
@@ -23,7 +23,6 @@ import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -31,6 +30,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import jakarta.inject.Inject;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 public class InterDynTest {
@@ -60,7 +61,7 @@ public class InterDynTest {
         return ShrinkWrap.create(WebArchive.class, "InterDynTest.war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addAsLibraries(testJar)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
     @Inject

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/jmx/CustomPropertiesTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/jmx/CustomPropertiesTest.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,6 +31,7 @@ import jakarta.inject.Inject;
 import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
 
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(Arquillian.class)
@@ -42,7 +42,7 @@ public class CustomPropertiesTest
     {
         return ShrinkWrap.create(WebArchive.class, "CustomPropertiesTest.war")
             .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
-            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addAsWebInfResource(BEANS_XML_ALL, "beans.xml")
             .addClasses(CustomProperties.class, CustomProperties2.class);
     }
 

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/jmx/CustomTypeTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/jmx/CustomTypeTest.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,6 +32,7 @@ import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
 
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -43,7 +43,7 @@ public class CustomTypeTest {
     {
         return ShrinkWrap.create(WebArchive.class, "CustomTypeTest.war")
             .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
-            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addAsWebInfResource(BEANS_XML_ALL, "beans.xml")
             .addClasses(CustomType.class);
     }
 

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/jmx/SimpleRegistrationWarFileTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/jmx/SimpleRegistrationWarFileTest.java
@@ -22,10 +22,11 @@ import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.runner.RunWith;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 public class SimpleRegistrationWarFileTest extends SimpleRegistrationTest
@@ -37,11 +38,11 @@ public class SimpleRegistrationWarFileTest extends SimpleRegistrationTest
 
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "simpleRegistrationTest.jar")
                 .addPackage(SimpleRegistrationWarFileTest.class.getPackage())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap.create(WebArchive.class, archiveName + ".war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addAsLibraries(testJar)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 }

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/scope/window/DefaultWindowContextTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/scope/window/DefaultWindowContextTest.java
@@ -26,13 +26,14 @@ import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.Assert;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 @Category(SeCategory.class)
@@ -43,12 +44,12 @@ public class DefaultWindowContextTest
     {
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "defaultWindowContextTest.jar")
                 .addPackage(DefaultWindowContextTest.class.getPackage().getName())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap.create(WebArchive.class, "defaultWindowContextTest.war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addAsLibraries(testJar)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
 

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/throttling/ThrottledTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/throttling/ThrottledTest.java
@@ -23,7 +23,6 @@ import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
@@ -38,6 +37,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Arrays.asList;
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -52,12 +52,12 @@ public class ThrottledTest {
     {
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "ThrottledTest.jar")
                 .addPackage(Service.class.getPackage().getName())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap.create(WebArchive.class, "ThrottledTest.war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addAsLibraries(testJar)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
     @Inject

--- a/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/util/JndiUtilsWarFileTest.java
+++ b/deltaspike/core/impl/src/test/java/org/apache/deltaspike/test/core/impl/util/JndiUtilsWarFileTest.java
@@ -23,11 +23,12 @@ import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 @Category(WebProfileCategory.class)
@@ -40,12 +41,12 @@ public class JndiUtilsWarFileTest extends JndiUtilsTest
         String archiveName = simpleName.substring(0, 1).toLowerCase() + simpleName.substring(1);
 
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "jndiTest.jar")
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap.create(WebArchive.class, archiveName + ".war")
                 .addPackage(JndiUtilsWarFileTest.class.getPackage())
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreArchive())
                 .addAsLibraries(testJar)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 }

--- a/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/util/jpa/Hibernate6QueryStringExtractor.java
+++ b/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/util/jpa/Hibernate6QueryStringExtractor.java
@@ -16,24 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.deltaspike.data.test.service;
+package org.apache.deltaspike.data.impl.util.jpa;
 
-import org.apache.deltaspike.data.api.*;
-import org.apache.deltaspike.data.test.domain.Simple;
-
-import static jakarta.persistence.LockModeType.PESSIMISTIC_READ;
-
-@Repository
-public interface ExtendedRepositoryInterface extends EntityRepository<Simple, Long>, EntityManagerDelegate<Simple>
+@ProviderSpecific("org.hibernate.query.Query")
+public class Hibernate6QueryStringExtractor extends BaseQueryStringExtractor
 {
 
-    @Query(lock = PESSIMISTIC_READ)
-    Simple findByName(String name);
-
-    @Query(named = Simple.BY_NAME_LIKE)
-    Simple findByNameNoLock(String name);
-
-    @Modifying @Query("delete from Simple")
-    int deleteAll();
+    @Override
+    public String extractFrom(Object query)
+    {
+        return (String) invoke("getQueryString", query);
+    }
 
 }

--- a/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/util/jpa/QueryStringExtractorFactory.java
+++ b/deltaspike/modules/data/impl/src/main/java/org/apache/deltaspike/data/impl/util/jpa/QueryStringExtractorFactory.java
@@ -27,6 +27,7 @@ public class QueryStringExtractorFactory
     private final QueryStringExtractor[] extractors = new QueryStringExtractor[]
     {
         new HibernateQueryStringExtractor(),
+        new Hibernate6QueryStringExtractor(),
         new EclipseLinkEjbQueryStringExtractor(),
         new OpenJpaQueryStringExtractor()
     };

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/handler/EntityRepositoryHandlerInheritedTest.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/handler/EntityRepositoryHandlerInheritedTest.java
@@ -28,6 +28,7 @@ import org.apache.deltaspike.data.test.domain.Simple5;
 import org.apache.deltaspike.data.test.service.ExtendedRepositoryAbstractInherited;
 import org.apache.deltaspike.data.test.service.ExtendedRepositoryAbstractIntermediate;
 import org.apache.deltaspike.test.category.WebProfileCategory;
+import org.apache.deltaspike.test.utils.BeansXmlUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.asset.Asset;
@@ -41,12 +42,10 @@ import jakarta.inject.Inject;
 public class EntityRepositoryHandlerInheritedTest extends TransactionalTestCase
 {
     
-    private static final Asset beansXml = new StringAsset("<beans bean-discovery-mode=\"all\"/>");
-
     @Deployment
     public static Archive<?> deployment()
     {
-        return initDeployment(true, beansXml)
+        return initDeployment(true)
                 .addClasses(ExtendedRepositoryAbstractIntermediate.class, 
                         ExtendedRepositoryAbstractInherited.class,
                         NamedQualifiedEntityManagerTestProducer.class)

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/tx/TransactionalQueryRunnerTest.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/impl/tx/TransactionalQueryRunnerTest.java
@@ -46,7 +46,7 @@ public class TransactionalQueryRunnerTest
     @Deployment
     public static Archive<?> deployment()
     {
-        return initDeployment()
+        return initDeployment(true, false)
                 .addClasses(ExtendedRepositoryInterface.class)
                 .addClass(TransactionalQueryRunnerWrapper.class)
                 .addPackage(Simple.class.getPackage());

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/BMTransactionStrategy.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/BMTransactionStrategy.java
@@ -16,24 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.deltaspike.data.test.service;
+package org.apache.deltaspike.data.test;
 
-import org.apache.deltaspike.data.api.*;
-import org.apache.deltaspike.data.test.domain.Simple;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.interceptor.Interceptor;
+import org.apache.deltaspike.jpa.impl.transaction.BeanManagedUserTransactionStrategy;
+import org.apache.deltaspike.jpa.impl.transaction.ContainerManagedTransactionStrategy;
 
-import static jakarta.persistence.LockModeType.PESSIMISTIC_READ;
-
-@Repository
-public interface ExtendedRepositoryInterface extends EntityRepository<Simple, Long>, EntityManagerDelegate<Simple>
+@Alternative
+@Priority(Interceptor.Priority.APPLICATION+1)
+public class BMTransactionStrategy extends BeanManagedUserTransactionStrategy
 {
-
-    @Query(lock = PESSIMISTIC_READ)
-    Simple findByName(String name);
-
-    @Query(named = Simple.BY_NAME_LIKE)
-    Simple findByNameNoLock(String name);
-
-    @Modifying @Query("delete from Simple")
-    int deleteAll();
-
 }

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/JpaTransactionStrategy.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/JpaTransactionStrategy.java
@@ -16,24 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.deltaspike.data.test.service;
+package org.apache.deltaspike.data.test;
 
-import org.apache.deltaspike.data.api.*;
-import org.apache.deltaspike.data.test.domain.Simple;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.interceptor.Interceptor;
+import org.apache.deltaspike.jpa.impl.transaction.ContainerManagedTransactionStrategy;
 
-import static jakarta.persistence.LockModeType.PESSIMISTIC_READ;
-
-@Repository
-public interface ExtendedRepositoryInterface extends EntityRepository<Simple, Long>, EntityManagerDelegate<Simple>
+@Alternative
+@Priority(Interceptor.Priority.APPLICATION+1)
+public class JpaTransactionStrategy extends ContainerManagedTransactionStrategy
 {
-
-    @Query(lock = PESSIMISTIC_READ)
-    Simple findByName(String name);
-
-    @Query(named = Simple.BY_NAME_LIKE)
-    Simple findByNameNoLock(String name);
-
-    @Modifying @Query("delete from Simple")
-    int deleteAll();
-
 }

--- a/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/java8/util/TestDeployments.java
+++ b/deltaspike/modules/data/impl/src/test/java/org/apache/deltaspike/data/test/java8/util/TestDeployments.java
@@ -20,11 +20,12 @@
 package org.apache.deltaspike.data.test.java8.util;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 
 import java.io.File;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 public class TestDeployments
 {
@@ -40,7 +41,7 @@ public class TestDeployments
                 .addAsLibraries(getDeltaSpikeDataWithDependencies())
                 .addClasses(EntityManagerProducer.class)
                 .addAsWebInfResource("test-persistence.xml", "classes/META-INF/persistence.xml")
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
 
         return archive;
     }

--- a/deltaspike/modules/jpa/impl/src/test/java/org/apache/deltaspike/test/jpa/api/transactional/aggregation/AggregatedDefaultEntityManagerInjectionTest.java
+++ b/deltaspike/modules/jpa/impl/src/test/java/org/apache/deltaspike/test/jpa/api/transactional/aggregation/AggregatedDefaultEntityManagerInjectionTest.java
@@ -29,7 +29,6 @@ import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
@@ -41,6 +40,8 @@ import org.junit.runner.RunWith;
 import jakarta.enterprise.inject.spi.Extension;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 @Category(SeCategory.class)
@@ -58,7 +59,7 @@ public class AggregatedDefaultEntityManagerInjectionTest
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "aggregatedDefaultInjectionTest.jar")
                 .addPackage(ArchiveUtils.SHARED_PACKAGE)
                 .addPackage(AggregatedDefaultEntityManagerInjectionTest.class.getPackage().getName())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap.create(WebArchive.class)
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreAndJpaArchive())

--- a/deltaspike/modules/jpa/impl/src/test/java/org/apache/deltaspike/test/jpa/api/transactional/defaultinjection/DefaultEntityManagerInjectionTest.java
+++ b/deltaspike/modules/jpa/impl/src/test/java/org/apache/deltaspike/test/jpa/api/transactional/defaultinjection/DefaultEntityManagerInjectionTest.java
@@ -30,7 +30,6 @@ import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
@@ -42,6 +41,8 @@ import org.junit.runner.RunWith;
 import jakarta.enterprise.inject.spi.Extension;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 @Category(SeCategory.class)
@@ -66,7 +67,7 @@ public class DefaultEntityManagerInjectionTest
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "defaultInjectionTest.jar")
                 .addPackage(ArchiveUtils.SHARED_PACKAGE)
                 .addPackage(DefaultEntityManagerInjectionTest.class.getPackage().getName())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap.create(WebArchive.class)
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreAndJpaArchive())

--- a/deltaspike/modules/jpa/impl/src/test/java/org/apache/deltaspike/test/jpa/api/transactional/defaultnested/DefaultNestedTransactionTest.java
+++ b/deltaspike/modules/jpa/impl/src/test/java/org/apache/deltaspike/test/jpa/api/transactional/defaultnested/DefaultNestedTransactionTest.java
@@ -29,7 +29,6 @@ import org.apache.deltaspike.test.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
@@ -40,6 +39,8 @@ import org.junit.runner.RunWith;
 
 import jakarta.enterprise.inject.spi.Extension;
 import jakarta.inject.Inject;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 @Category(SeCategory.class)
@@ -57,7 +58,7 @@ public class DefaultNestedTransactionTest
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "defaultNestedTransactionTest.jar")
                 .addPackage(ArchiveUtils.SHARED_PACKAGE)
                 .addPackage(DefaultNestedTransactionTest.class.getPackage().getName())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap.create(WebArchive.class)
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreAndJpaArchive())

--- a/deltaspike/modules/jsf/impl/pom.xml
+++ b/deltaspike/modules/jsf/impl/pom.xml
@@ -144,19 +144,19 @@
         <dependency>
             <groupId>org.jboss.arquillian.extension</groupId>
             <artifactId>arquillian-drone-api</artifactId>
-            <version>1.1.0.CR3</version>
+            <version>2.5.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.extension</groupId>
             <artifactId>arquillian-warp-api</artifactId>
-            <version>1.0.0.Alpha1</version>
+            <version>1.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.graphene</groupId>
             <artifactId>graphene-webdriver</artifactId>
-            <version>2.0.3.Final</version>
+            <version>2.5.4</version>
             <type>pom</type>
             <scope>test</scope>
             <exclusions>

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/controller/uc001/ViewConfigTestDrone.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/controller/uc001/ViewConfigTestDrone.java
@@ -23,6 +23,7 @@ import java.net.URL;
 
 import org.apache.deltaspike.test.category.WebProfileCategory;
 import org.apache.deltaspike.test.jsf.impl.util.ArchiveUtils;
+import org.apache.deltaspike.test.utils.BeansXmlUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
@@ -38,6 +39,8 @@ import org.junit.runner.RunWith;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 @Category(WebProfileCategory.class)
@@ -59,7 +62,7 @@ public class ViewConfigTestDrone
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeSecurityArchive())
                 .addAsWebResource("controller/simplePageConfig.xhtml", "/simplePageConfig.xhtml")
                 .addAsWebInfResource("default/WEB-INF/web.xml", "web.xml")
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
     @Test

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/controller/uc002/ViewConfigTestDrone.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/controller/uc002/ViewConfigTestDrone.java
@@ -23,6 +23,7 @@ import java.net.URL;
 
 import org.apache.deltaspike.test.category.WebProfileCategory;
 import org.apache.deltaspike.test.jsf.impl.util.ArchiveUtils;
+import org.apache.deltaspike.test.utils.BeansXmlUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
@@ -38,6 +39,8 @@ import org.junit.runner.RunWith;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 
 @RunWith(Arquillian.class)
@@ -60,7 +63,7 @@ public class ViewConfigTestDrone
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeSecurityArchive())
                 .addAsWebResource("controller/simplePageConfig.xhtml", "/simplePageConfig.xhtml")
                 .addAsWebInfResource("default/WEB-INF/web.xml", "web.xml")
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
     @Test

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/controller/uc003/ViewConfigTestDrone.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/controller/uc003/ViewConfigTestDrone.java
@@ -23,6 +23,7 @@ import java.net.URL;
 
 import org.apache.deltaspike.test.category.WebProfileCategory;
 import org.apache.deltaspike.test.jsf.impl.util.ArchiveUtils;
+import org.apache.deltaspike.test.utils.BeansXmlUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
@@ -38,6 +39,8 @@ import org.junit.runner.RunWith;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 
 @RunWith(Arquillian.class)
@@ -60,7 +63,7 @@ public class ViewConfigTestDrone
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeSecurityArchive())
                 .addAsWebResource("controller/simplePageConfig.xhtml", "/simplePageConfig.xhtml")
                 .addAsWebInfResource("default/WEB-INF/web.xml", "web.xml")
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
     @Test

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/navigation/destination/uc001/ViewConfigTestDrone.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/navigation/destination/uc001/ViewConfigTestDrone.java
@@ -23,6 +23,7 @@ import java.net.URL;
 
 import org.apache.deltaspike.test.category.WebProfileCategory;
 import org.apache.deltaspike.test.jsf.impl.util.ArchiveUtils;
+import org.apache.deltaspike.test.utils.BeansXmlUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
@@ -39,6 +40,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 
 @RunWith(Arquillian.class)
@@ -64,7 +67,7 @@ public class ViewConfigTestDrone
                 .addAsWebResource("navigation/pages/index.xhtml", "/pages/index.xhtml")
                 .addAsWebResource("navigation/pages/home.xhtml", "/pages/home.xhtml")
                 .addAsWebInfResource("default/WEB-INF/web.xml", "web.xml")
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
 

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/navigation/destination/uc002/ViewConfigTestDrone.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/navigation/destination/uc002/ViewConfigTestDrone.java
@@ -23,6 +23,7 @@ import java.net.URL;
 
 import org.apache.deltaspike.test.category.WebProfileCategory;
 import org.apache.deltaspike.test.jsf.impl.util.ArchiveUtils;
+import org.apache.deltaspike.test.utils.BeansXmlUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
@@ -39,6 +40,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 
 @RunWith(Arquillian.class)
@@ -66,7 +69,7 @@ public class ViewConfigTestDrone
                 .addAsWebResource("navigation/pages/overview.xhtml", "/pages/overview.xhtml")
                 .addAsWebResource("navigation/pages/customErrorPage.xhtml", "/pages/customErrorPage.xhtml")
                 .addAsWebInfResource("default/WEB-INF/web.xml", "web.xml")
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
     @Test

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/navigation/destination/uc003/ViewConfigTestDrone.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/navigation/destination/uc003/ViewConfigTestDrone.java
@@ -23,6 +23,7 @@ import java.net.URL;
 
 import org.apache.deltaspike.test.category.WebProfileCategory;
 import org.apache.deltaspike.test.jsf.impl.util.ArchiveUtils;
+import org.apache.deltaspike.test.utils.BeansXmlUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
@@ -39,6 +40,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 @Category(WebProfileCategory.class)
@@ -63,7 +66,7 @@ public class ViewConfigTestDrone
                 .addAsWebResource("navigation/pages/index.xhtml", "/pages/index.xhtml")
                 .addAsWebResource("navigation/pages/home.xhtml", "/pages/home.xhtml")
                 .addAsWebInfResource("default/WEB-INF/web.xml", "web.xml")
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
 

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/navigation/destination/uc004/ViewConfigTestDrone.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/navigation/destination/uc004/ViewConfigTestDrone.java
@@ -23,6 +23,7 @@ import java.net.URL;
 
 import org.apache.deltaspike.test.category.WebProfileCategory;
 import org.apache.deltaspike.test.jsf.impl.util.ArchiveUtils;
+import org.apache.deltaspike.test.utils.BeansXmlUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
@@ -39,6 +40,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 @Category(WebProfileCategory.class)
@@ -62,7 +65,7 @@ public class ViewConfigTestDrone
                 .addAsWebResource("navigation/pages/index.xhtml", "/pages/index.xhtml")
                 .addAsWebResource("navigation/pages/overview.xhtml", "/pages/overview.xhtml")
                 .addAsWebInfResource("default/WEB-INF/web.xml", "web.xml")
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
 

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/navigation/destination/uc006/ViewConfigTestDrone.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/navigation/destination/uc006/ViewConfigTestDrone.java
@@ -23,6 +23,7 @@ import java.net.URL;
 
 import org.apache.deltaspike.test.category.WebProfileCategory;
 import org.apache.deltaspike.test.jsf.impl.util.ArchiveUtils;
+import org.apache.deltaspike.test.utils.BeansXmlUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
@@ -39,6 +40,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 @Category(WebProfileCategory.class)
@@ -62,7 +65,7 @@ public class ViewConfigTestDrone
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeSecurityArchive())
                 .addAsWebResource("navigation/wizard1/step1.xhtml", "/wizard1/step1.xhtml")
                 .addAsWebInfResource("default/WEB-INF/web.xml", "web.xml")
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
 

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/navigation/event/uc001/PreViewConfigNavigateEventTest.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/navigation/event/uc001/PreViewConfigNavigateEventTest.java
@@ -23,6 +23,7 @@ import java.net.URL;
 
 import org.apache.deltaspike.test.category.WebProfileCategory;
 import org.apache.deltaspike.test.jsf.impl.util.ArchiveUtils;
+import org.apache.deltaspike.test.utils.BeansXmlUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
@@ -39,6 +40,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 @Category(WebProfileCategory.class)
@@ -66,7 +69,7 @@ public class PreViewConfigNavigateEventTest
                 .addAsWebResource("navigation/pages/overview.xhtml", "/pages/overview.xhtml")
                 .addAsWebResource("navigation/pages/customErrorPage.xhtml", "/pages/customErrorPage.xhtml")
                 .addAsWebInfResource("default/WEB-INF/web.xml", "web.xml")
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
         return archive;
     }
 
@@ -77,6 +80,7 @@ public class PreViewConfigNavigateEventTest
         driver.get(new URL(contextPath, "origin.xhtml").toString());
 
         WebElement button = driver.findElement(By.id("event:pb002ActionWithError"));
+        Assert.assertNotNull(button);
         button.click();
         // Index Page is shown instead of DefaultErrorView because PreViewConfigNavigateEvent changed the navigation
         Assert.assertTrue(ExpectedConditions.textToBePresentInElement(By.id("indexPage"), "You arrived at index page")

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/navigation/parameter/uc004/NavigationParameterTest.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/navigation/parameter/uc004/NavigationParameterTest.java
@@ -23,6 +23,7 @@ import java.net.URL;
 
 import org.apache.deltaspike.test.category.WebProfileCategory;
 import org.apache.deltaspike.test.jsf.impl.util.ArchiveUtils;
+import org.apache.deltaspike.test.utils.BeansXmlUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
@@ -39,6 +40,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 @Category(WebProfileCategory.class)
@@ -63,7 +66,7 @@ public class NavigationParameterTest
                 .addAsWebResource("navigation/origin.xhtml", "/origin.xhtml")
                 .addAsWebResource("navigation/simplePageConfig.xhtml", "/simplePageConfig.xhtml")
                 .addAsWebInfResource("default/WEB-INF/web.xml", "web.xml")
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
         return archive;
     }
 

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/navigation/parameter/uc005/NavigationParameterTest.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/navigation/parameter/uc005/NavigationParameterTest.java
@@ -23,6 +23,7 @@ import java.net.URL;
 
 import org.apache.deltaspike.test.category.WebProfileCategory;
 import org.apache.deltaspike.test.jsf.impl.util.ArchiveUtils;
+import org.apache.deltaspike.test.utils.BeansXmlUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
@@ -39,6 +40,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 @Category(WebProfileCategory.class)
@@ -64,7 +67,7 @@ public class NavigationParameterTest
                 .addAsWebResource("navigation/pages/index.xhtml", "/pages/index.xhtml")
                 .addAsWebResource("navigation/pages/overview.xhtml", "/pages/overview.xhtml")
                 .addAsWebInfResource("default/WEB-INF/web.xml", "web.xml")
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
         return archive;
     }
 

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/navigation/parameter/uc006/NavigationParameterTest.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/config/view/navigation/parameter/uc006/NavigationParameterTest.java
@@ -23,6 +23,7 @@ import java.net.URL;
 
 import org.apache.deltaspike.test.category.WebProfileCategory;
 import org.apache.deltaspike.test.jsf.impl.util.ArchiveUtils;
+import org.apache.deltaspike.test.utils.BeansXmlUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
@@ -39,6 +40,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 @Category(WebProfileCategory.class)
@@ -63,7 +66,7 @@ public class NavigationParameterTest
                 .addAsWebResource("navigation/origin.xhtml", "/origin.xhtml")
                 .addAsWebResource("navigation/pages/customErrorPage.xhtml", "/pages/customErrorPage.xhtml")
                 .addAsWebInfResource("default/WEB-INF/web.xml", "web.xml")
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
         return archive;
     }
 

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/injection/uc001/AnotherBeanConverter.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/injection/uc001/AnotherBeanConverter.java
@@ -25,8 +25,10 @@ import jakarta.faces.convert.Converter;
 import jakarta.faces.convert.ConverterException;
 import jakarta.faces.convert.FacesConverter;
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 
-@FacesConverter("myValueConverter")
+@Named
+@FacesConverter(value = "myValueConverter", managed = true)
 public class AnotherBeanConverter implements Converter
 {
 

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/injection/uc001/InjectionDroneTest.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/injection/uc001/InjectionDroneTest.java
@@ -23,6 +23,7 @@ import java.net.URL;
 
 import org.apache.deltaspike.test.category.WebProfileCategory;
 import org.apache.deltaspike.test.jsf.impl.util.ArchiveUtils;
+import org.apache.deltaspike.test.utils.BeansXmlUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
@@ -39,6 +40,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 
 @RunWith(Arquillian.class)
@@ -61,7 +64,7 @@ public class InjectionDroneTest
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeSecurityArchive())
                 .addAsWebResource("injection/testValidatorConverter.xhtml", "/testValidatorConverter.xhtml")
                 .addAsWebInfResource("default/WEB-INF/web.xml", "web.xml")
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
     @Test

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/injection/uc001/MyBeanValidator.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/injection/uc001/MyBeanValidator.java
@@ -25,8 +25,10 @@ import jakarta.faces.validator.FacesValidator;
 import jakarta.faces.validator.Validator;
 import jakarta.faces.validator.ValidatorException;
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 
-@FacesValidator("myBeanValidator")
+@Named
+@FacesValidator(value = "myBeanValidator", managed = true)
 public class MyBeanValidator implements Validator
 {
 

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/injection/uc002/AnotherBeanConverter.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/injection/uc002/AnotherBeanConverter.java
@@ -19,6 +19,7 @@
 package org.apache.deltaspike.test.jsf.impl.injection.uc002;
 
 import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.Model;
 import jakarta.faces.application.FacesMessage;
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.context.FacesContext;
@@ -26,9 +27,11 @@ import jakarta.faces.convert.Converter;
 import jakarta.faces.convert.ConverterException;
 import jakarta.faces.convert.FacesConverter;
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 
+@Named
 @RequestScoped
-@FacesConverter("myValueConverter")
+@FacesConverter(value = "myValueConverter", managed = true)
 public class AnotherBeanConverter implements Converter
 {
 

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/injection/uc002/InjectionDroneTest.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/injection/uc002/InjectionDroneTest.java
@@ -23,6 +23,7 @@ import java.net.URL;
 
 import org.apache.deltaspike.test.category.WebProfileCategory;
 import org.apache.deltaspike.test.jsf.impl.util.ArchiveUtils;
+import org.apache.deltaspike.test.utils.BeansXmlUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
@@ -39,6 +40,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 @Category(WebProfileCategory.class)
@@ -60,7 +63,7 @@ public class InjectionDroneTest
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeSecurityArchive())
                 .addAsWebResource("injection/testValidatorConverter.xhtml", "/testValidatorConverter.xhtml")
                 .addAsWebInfResource("default/WEB-INF/web.xml", "web.xml")
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
     @Test

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/injection/uc002/MyBeanValidator.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/injection/uc002/MyBeanValidator.java
@@ -26,9 +26,11 @@ import jakarta.faces.validator.FacesValidator;
 import jakarta.faces.validator.Validator;
 import jakarta.faces.validator.ValidatorException;
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 
+@Named
 @RequestScoped
-@FacesValidator("myBeanValidator")
+@FacesValidator(value = "myBeanValidator", managed = true)
 public class MyBeanValidator implements Validator
 {
 

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/injection/uc003/AnotherBeanConverter.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/injection/uc003/AnotherBeanConverter.java
@@ -25,8 +25,10 @@ import jakarta.faces.convert.Converter;
 import jakarta.faces.convert.ConverterException;
 import jakarta.faces.convert.FacesConverter;
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 
-@FacesConverter("myValueConverter")
+@Named
+@FacesConverter(value = "myValueConverter", managed = true)
 public class AnotherBeanConverter extends AbstractStateHolder implements Converter
 {
 

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/injection/uc003/InjectionDroneTest.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/injection/uc003/InjectionDroneTest.java
@@ -23,6 +23,7 @@ import java.net.URL;
 
 import org.apache.deltaspike.test.category.WebProfileCategory;
 import org.apache.deltaspike.test.jsf.impl.util.ArchiveUtils;
+import org.apache.deltaspike.test.utils.BeansXmlUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
@@ -39,6 +40,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 @Category(WebProfileCategory.class)
@@ -62,7 +65,7 @@ public class InjectionDroneTest
                 .addAsWebInfResource("META-INF/test.taglib.xml", "classes/META-INF/test.taglib.xml")
                 .addAsWebInfResource("default/WEB-INF/web.xml", "web.xml")
                 .addAsWebInfResource("default/WEB-INF/faces-config.xml", "faces-config.xml")
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
     @Test

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/injection/uc003/MyBeanValidator.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/injection/uc003/MyBeanValidator.java
@@ -25,8 +25,10 @@ import jakarta.faces.validator.FacesValidator;
 import jakarta.faces.validator.Validator;
 import jakarta.faces.validator.ValidatorException;
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 
-@FacesValidator("myBeanValidator")
+@Named
+@FacesValidator(value = "myBeanValidator", managed = true)
 public class MyBeanValidator extends AbstractStateHolder implements Validator
 {
 

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/injection/uc004/AnotherBeanConverter.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/injection/uc004/AnotherBeanConverter.java
@@ -25,8 +25,10 @@ import jakarta.faces.convert.Converter;
 import jakarta.faces.convert.ConverterException;
 import jakarta.faces.convert.FacesConverter;
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 
-@FacesConverter("myValueConverter")
+@Named
+@FacesConverter(value = "myValueConverter", managed = true)
 public class AnotherBeanConverter implements Converter
 {
 

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/injection/uc004/InjectionDroneTest.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/injection/uc004/InjectionDroneTest.java
@@ -23,6 +23,7 @@ import java.net.URL;
 
 import org.apache.deltaspike.test.category.WebProfileCategory;
 import org.apache.deltaspike.test.jsf.impl.util.ArchiveUtils;
+import org.apache.deltaspike.test.utils.BeansXmlUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
@@ -39,6 +40,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 @Category(WebProfileCategory.class)
@@ -62,7 +65,7 @@ public class InjectionDroneTest
                 .addAsWebInfResource("META-INF/test.taglib.xml", "classes/META-INF/test.taglib.xml")
                 .addAsWebInfResource("default/WEB-INF/web.xml", "web.xml")
                 .addAsWebInfResource("default/WEB-INF/faces-config.xml", "faces-config.xml")
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
     @Test

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/injection/uc004/MyBeanValidator.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/injection/uc004/MyBeanValidator.java
@@ -26,15 +26,17 @@ import jakarta.faces.validator.FacesValidator;
 import jakarta.faces.validator.Validator;
 import jakarta.faces.validator.ValidatorException;
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 
-@FacesValidator("myBeanValidator")
+@Named
+@FacesValidator(value = "myBeanValidator", managed = true)
 public class MyBeanValidator implements Validator, StateHolder
 {
 
     @Inject
     private MyBean myBean;
 
-    private String validValue = "Apache";
+    private String validValue = "DeltaSpike";
     
     private boolean isTransient;
 

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/message/JsfMessageTest.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/message/JsfMessageTest.java
@@ -25,6 +25,7 @@ import org.apache.deltaspike.test.category.WebProfileCategory;
 import org.apache.deltaspike.test.jsf.impl.config.TestJsfModuleConfig;
 import org.apache.deltaspike.test.jsf.impl.message.beans.JsfMessageBackingBean;
 import org.apache.deltaspike.test.jsf.impl.util.ArchiveUtils;
+import org.apache.deltaspike.test.utils.BeansXmlUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
@@ -40,6 +41,8 @@ import org.junit.runner.RunWith;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 
 /**
@@ -68,7 +71,7 @@ public class JsfMessageTest
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeSecurityArchive())
                 .addAsWebInfResource("default/WEB-INF/web.xml", "web.xml")
                 .addAsWebResource("jsfMessageTest/page.xhtml", "page.xhtml")
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
 

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/scope/viewaccess/ViewAccessScopedWebAppTest.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/scope/viewaccess/ViewAccessScopedWebAppTest.java
@@ -24,6 +24,7 @@ import org.apache.deltaspike.test.category.WebProfileCategory;
 import org.apache.deltaspike.test.jsf.impl.scope.viewaccess.beans.ViewAccessScopedBeanX;
 import org.apache.deltaspike.test.jsf.impl.scope.viewaccess.beans.ViewAccessScopedBeanY;
 import org.apache.deltaspike.test.jsf.impl.util.ArchiveUtils;
+import org.apache.deltaspike.test.utils.BeansXmlUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
@@ -40,6 +41,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 @Category(WebProfileCategory.class)
@@ -66,7 +69,7 @@ public class ViewAccessScopedWebAppTest
                 .addAsWebInfResource("default/WEB-INF/web.xml", "web.xml")
                 .addAsWebResource("viewAccessScopedContextTest/page1.xhtml", "page1.xhtml")
                 .addAsWebResource("viewAccessScopedContextTest/page2.xhtml", "page2.xhtml")
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
     @Test

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/scope/viewaccess/ViewAccessScopedWithFViewActionWebAppTest.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/scope/viewaccess/ViewAccessScopedWithFViewActionWebAppTest.java
@@ -24,6 +24,7 @@ import org.apache.deltaspike.test.category.WebEEProfileCategory;
 import org.apache.deltaspike.test.jsf.impl.scope.viewaccess.beans.ViewAccessScopedBeanX;
 import org.apache.deltaspike.test.jsf.impl.scope.viewaccess.beans.ViewAccessScopedBeanY;
 import org.apache.deltaspike.test.jsf.impl.util.ArchiveUtils;
+import org.apache.deltaspike.test.utils.BeansXmlUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
@@ -40,6 +41,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 @Category(WebEEProfileCategory.class)
@@ -66,7 +69,7 @@ public class ViewAccessScopedWithFViewActionWebAppTest
                 .addAsWebInfResource("default/WEB-INF/web.xml", "web.xml")
                 .addAsWebResource("viewAccessScopedContextTest/index.xhtml", "index.xhtml")
                 .addAsWebResource("viewAccessScopedContextTest/next.xhtml", "next.xhtml")
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
     @Test

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/scope/window/WindowMaxCountTest.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/scope/window/WindowMaxCountTest.java
@@ -23,6 +23,7 @@ import java.net.URL;
 
 import org.apache.deltaspike.test.category.WebProfileCategory;
 import org.apache.deltaspike.test.jsf.impl.util.ArchiveUtils;
+import org.apache.deltaspike.test.utils.BeansXmlUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
@@ -38,6 +39,8 @@ import org.junit.runner.RunWith;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 @Category(WebProfileCategory.class)
@@ -62,7 +65,7 @@ public class WindowMaxCountTest
                 .addAsWebInfResource("default/WEB-INF/web.xml", "web.xml")
                 .addAsWebInfResource("META-INF/apache-deltaspike.properties",
                         "classes/META-INF/apache-deltaspike.properties")
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
         return archive;
     }
 

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/scope/window/WindowScopedContextFrameTest.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/scope/window/WindowScopedContextFrameTest.java
@@ -23,6 +23,7 @@ import org.apache.deltaspike.test.category.WebProfileCategory;
 import org.apache.deltaspike.test.jsf.impl.config.TestJsfModuleConfig;
 import org.apache.deltaspike.test.jsf.impl.scope.window.beans.WindowScopedBackingBean;
 import org.apache.deltaspike.test.jsf.impl.util.ArchiveUtils;
+import org.apache.deltaspike.test.utils.BeansXmlUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
@@ -41,6 +42,8 @@ import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 
 import java.net.URL;
 import java.util.logging.Logger;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 
 /**
@@ -72,7 +75,7 @@ public class WindowScopedContextFrameTest
                                   "resources/deltaspike/windowhandler.js")
                 .addAsWebResource("windowScopedContextTest/framecontainer.xhtml", "framecontainer.xhtml")
                 .addAsWebResource("windowScopedContextTest/frame.xhtml", "frame.xhtml")
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
 

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/scope/window/WindowScopedContextTest.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/scope/window/WindowScopedContextTest.java
@@ -23,6 +23,7 @@ import org.apache.deltaspike.test.category.WebProfileCategory;
 import org.apache.deltaspike.test.jsf.impl.config.TestJsfModuleConfig;
 import org.apache.deltaspike.test.jsf.impl.scope.window.beans.WindowScopedBackingBean;
 import org.apache.deltaspike.test.jsf.impl.util.ArchiveUtils;
+import org.apache.deltaspike.test.utils.BeansXmlUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
@@ -42,6 +43,8 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.net.URL;
 import java.util.logging.Logger;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 
 /**
@@ -73,7 +76,7 @@ public class WindowScopedContextTest
                                   "resources/deltaspike/windowhandler.js")
                 .addAsWebResource("windowScopedContextTest/page.xhtml", "page.xhtml")
                 .addAsWebResource("windowScopedContextTest/page2.xhtml", "page2.xhtml")
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 
 

--- a/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/util/ArchiveUtils.java
+++ b/deltaspike/modules/jsf/impl/src/test/java/org/apache/deltaspike/test/jsf/impl/util/ArchiveUtils.java
@@ -84,7 +84,7 @@ public class ArchiveUtils
     public static Asset getBeansXml()
     {
         Asset beansXml = new StringAsset(
-            "<beans>" +
+            "<beans bean-discovery-mode=\"all\">" +
                 "<interceptors>" +
                     "<class>org.apache.deltaspike.jsf.impl.config.view.navigation.NavigationParameterInterceptor</class>" +
                     "<class>org.apache.deltaspike.jsf.impl.config.view.navigation.NavigationParameterListInterceptor</class>" +

--- a/deltaspike/modules/partial-bean/impl/src/test/java/org/apache/deltaspike/test/core/api/partialbean/uc004/ScopedPartialBeanTest.java
+++ b/deltaspike/modules/partial-bean/impl/src/test/java/org/apache/deltaspike/test/core/api/partialbean/uc004/ScopedPartialBeanTest.java
@@ -21,6 +21,7 @@ package org.apache.deltaspike.test.core.api.partialbean.uc004;
 import org.apache.deltaspike.core.api.provider.BeanProvider;
 import org.apache.deltaspike.test.core.api.partialbean.shared.TestPartialBeanBinding;
 import org.apache.deltaspike.test.core.api.partialbean.util.ArchiveUtils;
+import org.apache.deltaspike.test.utils.BeansXmlUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -30,6 +31,8 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 public class ScopedPartialBeanTest
@@ -43,12 +46,12 @@ public class ScopedPartialBeanTest
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, archiveName + ".jar")
                 .addPackage(ScopedPartialBeanTest.class.getPackage())
                 .addPackage(TestPartialBeanBinding.class.getPackage())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         WebArchive webArchive =  ShrinkWrap.create(WebArchive.class, archiveName + ".war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreAndPartialBeanArchive())
                 .addAsLibraries(testJar)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
 
         return webArchive;
     }

--- a/deltaspike/modules/partial-bean/impl/src/test/java/org/apache/deltaspike/test/core/api/partialbean/uc007/MethodLevelInterceptorTest.java
+++ b/deltaspike/modules/partial-bean/impl/src/test/java/org/apache/deltaspike/test/core/api/partialbean/uc007/MethodLevelInterceptorTest.java
@@ -45,7 +45,7 @@ public class MethodLevelInterceptorTest
     public static WebArchive war()
     {
         Asset beansXml = new StringAsset(
-            "<beans><interceptors><class>" +
+            "<beans bean-discovery-mode=\"all\"><interceptors><class>" +
                     CustomInterceptorImpl.class.getName() +
             "</class></interceptors></beans>"
         );

--- a/deltaspike/modules/partial-bean/impl/src/test/java/org/apache/deltaspike/test/core/api/partialbean/uc008/ClassLevelInterceptorTest.java
+++ b/deltaspike/modules/partial-bean/impl/src/test/java/org/apache/deltaspike/test/core/api/partialbean/uc008/ClassLevelInterceptorTest.java
@@ -45,7 +45,7 @@ public class ClassLevelInterceptorTest
     public static WebArchive war()
     {
         Asset beansXml = new StringAsset(
-            "<beans><interceptors><class>" +
+            "<beans bean-discovery-mode=\"all\"><interceptors><class>" +
                     CustomInterceptorImpl.class.getName() +
             "</class></interceptors></beans>"
         );

--- a/deltaspike/modules/partial-bean/impl/src/test/java/org/apache/deltaspike/test/core/api/partialbean/uc009/PartialBeanWithProducerWarFileTest.java
+++ b/deltaspike/modules/partial-bean/impl/src/test/java/org/apache/deltaspike/test/core/api/partialbean/uc009/PartialBeanWithProducerWarFileTest.java
@@ -19,6 +19,7 @@
 package org.apache.deltaspike.test.core.api.partialbean.uc009;
 
 import org.apache.deltaspike.test.core.api.partialbean.util.ArchiveUtils;
+import org.apache.deltaspike.test.utils.BeansXmlUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -26,6 +27,8 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.runner.RunWith;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 public class PartialBeanWithProducerWarFileTest extends PartialBeanWithProducerTest
@@ -38,11 +41,11 @@ public class PartialBeanWithProducerWarFileTest extends PartialBeanWithProducerT
 
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, archiveName + ".jar")
                 .addPackage(PartialBeanWithProducerWarFileTest.class.getPackage())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
         return ShrinkWrap.create(WebArchive.class, archiveName + ".war")
                 .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreAndPartialBeanArchive())
                 .addAsLibraries(testJar)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
     }
 }

--- a/deltaspike/modules/partial-bean/impl/src/test/java/org/apache/deltaspike/test/core/api/partialbean/uc012/ConcurrencyBugTest.java
+++ b/deltaspike/modules/partial-bean/impl/src/test/java/org/apache/deltaspike/test/core/api/partialbean/uc012/ConcurrencyBugTest.java
@@ -19,28 +19,22 @@
 
 package org.apache.deltaspike.test.core.api.partialbean.uc012;
 
+import jakarta.inject.Inject;
 import org.apache.deltaspike.test.core.api.partialbean.util.ArchiveUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.*;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 public class ConcurrencyBugTest
@@ -54,12 +48,12 @@ public class ConcurrencyBugTest
 
       final JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, archiveName + ".jar")
             .addPackage(ConcurrencyBugTest.class.getPackage())
-            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+            .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
 
       final WebArchive webArchive =  ShrinkWrap.create(WebArchive.class, archiveName + ".war")
             .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreAndPartialBeanArchive())
             .addAsLibraries(testJar)
-            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+            .addAsWebInfResource(BEANS_XML_ALL, "beans.xml");
 
       return webArchive;
    }

--- a/deltaspike/modules/partial-bean/impl/src/test/java/org/apache/deltaspike/test/core/api/partialbean/uc013/MethodLevelInterceptorTest.java
+++ b/deltaspike/modules/partial-bean/impl/src/test/java/org/apache/deltaspike/test/core/api/partialbean/uc013/MethodLevelInterceptorTest.java
@@ -45,7 +45,7 @@ public class MethodLevelInterceptorTest
     public static WebArchive war()
     {
         Asset beansXml = new StringAsset(
-            "<beans><interceptors><class>" +
+            "<beans bean-discover-mode=\"all\"><interceptors><class>" +
                     SimpleCacheInterceptor.class.getName() +
             "</class></interceptors></beans>"
         );

--- a/deltaspike/modules/scheduler/impl/src/test/java/org/apache/deltaspike/test/scheduler/custom/CustomSchedulerWarFileTest.java
+++ b/deltaspike/modules/scheduler/impl/src/test/java/org/apache/deltaspike/test/scheduler/custom/CustomSchedulerWarFileTest.java
@@ -21,6 +21,7 @@ package org.apache.deltaspike.test.scheduler.custom;
 import org.apache.deltaspike.core.spi.config.ConfigSource;
 import org.apache.deltaspike.scheduler.spi.Scheduler;
 import org.apache.deltaspike.test.util.ArchiveUtils;
+import org.apache.deltaspike.test.utils.BeansXmlUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -30,6 +31,8 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import org.junit.runner.RunWith;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 @RunWith(Arquillian.class)
 public class CustomSchedulerWarFileTest extends CustomSchedulerTest
@@ -42,7 +45,7 @@ public class CustomSchedulerWarFileTest extends CustomSchedulerTest
 
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "customSchedulerTest.jar")
                 .addPackage(CustomSchedulerWarFileTest.class.getPackage().getName())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml")
                 .addAsResource(new StringAsset(MockedScheduler.class.getName()),
                         "META-INF/services/" + Scheduler.class.getName())
                 .addAsResource(new StringAsset(CustomConfigSource.class.getName()),

--- a/deltaspike/modules/scheduler/impl/src/test/java/org/apache/deltaspike/test/scheduler/custom/ScopeNotStartedTest.java
+++ b/deltaspike/modules/scheduler/impl/src/test/java/org/apache/deltaspike/test/scheduler/custom/ScopeNotStartedTest.java
@@ -22,6 +22,7 @@ import junit.framework.Assert;
 import org.apache.deltaspike.core.spi.config.ConfigSource;
 import org.apache.deltaspike.scheduler.spi.Scheduler;
 import org.apache.deltaspike.test.util.ArchiveUtils;
+import org.apache.deltaspike.test.utils.BeansXmlUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -35,6 +36,8 @@ import org.junit.runner.RunWith;
 
 import jakarta.inject.Inject;
 
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
+
 @RunWith(Arquillian.class)
 public class ScopeNotStartedTest
 {
@@ -47,7 +50,7 @@ public class ScopeNotStartedTest
 
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "scopeNotStartedTest.jar")
                 .addPackage(CustomSchedulerWarFileTest.class.getPackage().getName())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml")
                 .addAsResource(new StringAsset(MockedScheduler.class.getName()),
                         "META-INF/services/" + Scheduler.class.getName())
                 .addAsResource(new StringAsset(CustomDeactivatedConfigSource.class.getName()),

--- a/deltaspike/parent/code/pom.xml
+++ b/deltaspike/parent/code/pom.xml
@@ -37,7 +37,6 @@
     <properties>
         <container.unpack.directory>${java.io.tmpdir}/deltaspike-arquillian-containers</container.unpack.directory>
         <wildfly.version>31.0.0.Final</wildfly.version>
-        <weld.el.api>5.0.0</weld.el.api>
         <weld.sfl4j>2.0.11</weld.sfl4j>
         <wildfly.arquillian.version>5.0.1.Final</wildfly.arquillian.version>
         <payara.version>6.2024.1</payara.version>
@@ -437,19 +436,19 @@
                 <dependency>
                     <groupId>jakarta.el</groupId>
                     <artifactId>jakarta.el-api</artifactId>
-                    <version>${weld.el.api}</version>
+                    <version>${jakarta.el-api.version}</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>
                     <groupId>jakarta.transaction</groupId>
                     <artifactId>jakarta.transaction-api</artifactId>
-                    <version>2.0.1</version>
+                    <version>${jakarta.transaction-api.version}</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>
                     <groupId>jakarta.interceptor</groupId>
                     <artifactId>jakarta.interceptor-api</artifactId>
-                    <version>2.1.0</version>
+                    <version>${jakarta.interceptor-api.version}</version>
                 </dependency>
 
                 <!-- Test dependencies -->
@@ -677,6 +676,11 @@
                     <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
                     <version>${arquillian.version}</version>
                     <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>jakarta.servlet</groupId>
+                    <artifactId>jakarta.servlet-api</artifactId>
+                    <version>${jakarta.servlet-api.version}</version>
                 </dependency>
             </dependencies>
 

--- a/deltaspike/parent/pom.xml
+++ b/deltaspike/parent/pom.xml
@@ -123,9 +123,10 @@
         <jakarta.cdi-api.version>4.0.0</jakarta.cdi-api.version>
         <jakarta.interceptor-api.version>2.0.0</jakarta.interceptor-api.version>
         <jakarta.annotation-api.version>2.0.0</jakarta.annotation-api.version>
-        <jakarta.el-api.version>4.0.0</jakarta.el-api.version>
+        <jakarta.el-api.version>5.0.0</jakarta.el-api.version>
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
         <jakarta.transaction-api.version>2.0.0</jakarta.transaction-api.version>
+        <jakarta.servlet-api.version>6.0.0</jakarta.servlet-api.version>
     </properties>
 
     <profiles>

--- a/deltaspike/test-utils/src/main/java/org/apache/deltaspike/test/arquillian/DeltaSpikeServerUtilAppender.java
+++ b/deltaspike/test-utils/src/main/java/org/apache/deltaspike/test/arquillian/DeltaSpikeServerUtilAppender.java
@@ -23,8 +23,9 @@ import org.apache.deltaspike.test.utils.Serializer;
 import org.jboss.arquillian.container.test.spi.client.deployment.CachedAuxilliaryArchiveAppender;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+import static org.apache.deltaspike.test.utils.BeansXmlUtil.BEANS_XML_ALL;
 
 public class DeltaSpikeServerUtilAppender extends CachedAuxilliaryArchiveAppender
 {
@@ -34,6 +35,6 @@ public class DeltaSpikeServerUtilAppender extends CachedAuxilliaryArchiveAppende
         return ShrinkWrap.create(JavaArchive.class, "test-utils.jar")
                 .addPackage(Serializer.class.getPackage())
                 .addPackage(DeltaSpikeTest.class.getPackage())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(BEANS_XML_ALL, "beans.xml");
     }
 }

--- a/deltaspike/test-utils/src/main/java/org/apache/deltaspike/test/utils/BeansXmlUtil.java
+++ b/deltaspike/test-utils/src/main/java/org/apache/deltaspike/test/utils/BeansXmlUtil.java
@@ -16,24 +16,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.deltaspike.data.test.service;
+package org.apache.deltaspike.test.utils;
 
-import org.apache.deltaspike.data.api.*;
-import org.apache.deltaspike.data.test.domain.Simple;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 
-import static jakarta.persistence.LockModeType.PESSIMISTIC_READ;
-
-@Repository
-public interface ExtendedRepositoryInterface extends EntityRepository<Simple, Long>, EntityManagerDelegate<Simple>
+public class BeansXmlUtil
 {
+    /**
+     * A Beans.xml instance enabling Discovery-Mode ALL for unit tests
+     */
+    public static final Asset BEANS_XML_ALL = new StringAsset("<beans bean-discovery-mode=\"all\"/>");
 
-    @Query(lock = PESSIMISTIC_READ)
-    Simple findByName(String name);
-
-    @Query(named = Simple.BY_NAME_LIKE)
-    Simple findByNameNoLock(String name);
-
-    @Modifying @Query("delete from Simple")
-    int deleteAll();
+    private BeansXmlUtil()
+    {
+    }
 
 }

--- a/deltaspike/test-utils/src/main/java/org/apache/deltaspike/test/utils/ShrinkWrapArchiveUtil.java
+++ b/deltaspike/test-utils/src/main/java/org/apache/deltaspike/test/utils/ShrinkWrapArchiveUtil.java
@@ -26,11 +26,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.logging.Logger;
 
 


### PR DESCRIPTION
Tests: bean-discovery-mode=all provided by BeansXmlUtil
Hibernate6QueryStringExtractor for Hibernate-ORM
wildfly-build-managed 
- most test working
- open: JSF - Mojarra-Bug on redirection:
```
20:13:53,624 ERROR [io.undertow.request] (default task-1) UT005023: Exception handling request to /test/page.xhtml: java.lang.NullPointerException
        at jakarta.faces.impl@4.0.5//com.sun.faces.context.ExternalContextImpl.encodeRedirectURL(ExternalContextImpl.java:996)
        at jakarta.faces.impl@4.0.5//jakarta.faces.context.ExternalContextWrapper.encodeRedirectURL(ExternalContextWrapper.java:1064)
        at deployment.test.war//org.apache.deltaspike.jsf.impl.util.ClientWindowHelper.constructRequestUrl(ClientWindowHelper.java:64)
        at deployment.test.war//org.apache.deltaspike.jsf.impl.util.ClientWindowHelper.handleInitialRedirect(ClientWindowHelper.java:83)
        at deployment.test.war//org.apache.deltaspike.jsf.impl.clientwindow.LazyClientWindow.decode(LazyClientWindow.java:57)
```
- Partial Bean: Interceptors still not working - no interception happening