### PR TITLE
Weld5 needs Priority annotation on Interceptor

### DIFF
--- a/deltaspike/modules/partial-bean/impl/src/test/java/org/apache/deltaspike/test/core/api/partialbean/shared/CustomInterceptorImpl.java
+++ b/deltaspike/modules/partial-bean/impl/src/test/java/org/apache/deltaspike/test/core/api/partialbean/shared/CustomInterceptorImpl.java
@@ -19,11 +19,14 @@
 package org.apache.deltaspike.test.core.api.partialbean.shared;
 
 import java.io.Serializable;
+
+import jakarta.annotation.Priority;
 import jakarta.inject.Inject;
 import jakarta.interceptor.AroundInvoke;
 import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InvocationContext;
 
+@Priority(Interceptor.Priority.APPLICATION)
 @Interceptor
 @CustomInterceptor
 public class CustomInterceptorImpl implements Serializable

--- a/deltaspike/modules/partial-bean/impl/src/test/java/org/apache/deltaspike/test/core/api/partialbean/uc007/MethodLevelInterceptorTest.java
+++ b/deltaspike/modules/partial-bean/impl/src/test/java/org/apache/deltaspike/test/core/api/partialbean/uc007/MethodLevelInterceptorTest.java
@@ -19,6 +19,7 @@
 package org.apache.deltaspike.test.core.api.partialbean.uc007;
 
 import org.apache.deltaspike.core.api.provider.BeanProvider;
+import org.apache.deltaspike.test.core.api.partialbean.shared.CustomInterceptor;
 import org.apache.deltaspike.test.core.api.partialbean.shared.CustomInterceptorImpl;
 import org.apache.deltaspike.test.core.api.partialbean.shared.CustomInterceptorState;
 import org.apache.deltaspike.test.core.api.partialbean.shared.TestPartialBeanBinding;
@@ -39,8 +40,6 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class MethodLevelInterceptorTest
 {
-    public static final String CONTAINER_WELD_2_0_0 = "weld-2\\.0\\.0\\..*";
-
     @Deployment
     public static WebArchive war()
     {
@@ -53,16 +52,9 @@ public class MethodLevelInterceptorTest
         String simpleName = MethodLevelInterceptorTest.class.getSimpleName();
         String archiveName = simpleName.substring(0, 1).toLowerCase() + simpleName.substring(1);
 
-        //don't create a completely empty web-archive
-        if (CdiContainerUnderTest.is(CONTAINER_WELD_2_0_0))
-        {
-            return ShrinkWrap.create(WebArchive.class, archiveName + ".war")
-                    .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreAndPartialBeanArchive());
-        }
-
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, archiveName + ".jar")
-                .addPackage(MethodLevelInterceptorTest.class.getPackage())
-                .addPackage(TestPartialBeanBinding.class.getPackage())
+                .addPackage(PartialBean.class.getPackage())
+                .addPackage(CustomInterceptor.class.getPackage())
                 .addAsManifestResource(beansXml, "beans.xml");
 
         return ShrinkWrap.create(WebArchive.class, archiveName + ".war")
@@ -74,9 +66,6 @@ public class MethodLevelInterceptorTest
     @Test
     public void testMethodLevelInterceptor() throws Exception
     {
-        // this test is known to not work under weld-2.0.0.Final and weld-2.0.0.SP1
-        Assume.assumeTrue(!CdiContainerUnderTest.is(CONTAINER_WELD_2_0_0));
-
         PartialBean partialBean = BeanProvider.getContextualReference(PartialBean.class);
         CustomInterceptorState state = BeanProvider.getContextualReference(CustomInterceptorState.class);
 
@@ -88,9 +77,6 @@ public class MethodLevelInterceptorTest
     @Test
     public void testMethodLevelInterceptorStereotype() throws Exception
     {
-        // this test is known to not work under weld-2.0.0.Final and weld-2.0.0.SP1
-        Assume.assumeTrue(!CdiContainerUnderTest.is(CONTAINER_WELD_2_0_0));
-
         PartialBean partialBean = BeanProvider.getContextualReference(PartialBean.class);
         CustomInterceptorState state = BeanProvider.getContextualReference(CustomInterceptorState.class);
 
@@ -102,9 +88,6 @@ public class MethodLevelInterceptorTest
     @Test
     public void testMethodLevelInterceptorOnAbstractMethod() throws Exception
     {
-        // this test is known to not work under weld-2.0.0.Final and weld-2.0.0.SP1
-        Assume.assumeTrue(!CdiContainerUnderTest.is(CONTAINER_WELD_2_0_0));
-
         PartialBean partialBean = BeanProvider.getContextualReference(PartialBean.class);
         CustomInterceptorState state = BeanProvider.getContextualReference(CustomInterceptorState.class);
 

--- a/deltaspike/modules/partial-bean/impl/src/test/java/org/apache/deltaspike/test/core/api/partialbean/uc008/ClassLevelInterceptorTest.java
+++ b/deltaspike/modules/partial-bean/impl/src/test/java/org/apache/deltaspike/test/core/api/partialbean/uc008/ClassLevelInterceptorTest.java
@@ -39,8 +39,6 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class ClassLevelInterceptorTest
 {
-    public static final String CONTAINER_WELD_2_0_0 = "weld-2\\.0\\.0\\..*";
-
     @Deployment
     public static WebArchive war()
     {
@@ -52,13 +50,6 @@ public class ClassLevelInterceptorTest
 
         String simpleName = ClassLevelInterceptorTest.class.getSimpleName();
         String archiveName = simpleName.substring(0, 1).toLowerCase() + simpleName.substring(1);
-
-        //don't create a completely empty web-archive
-        if (CdiContainerUnderTest.is(CONTAINER_WELD_2_0_0))
-        {
-            return ShrinkWrap.create(WebArchive.class, archiveName + ".war")
-                    .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreAndPartialBeanArchive());
-        }
 
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, archiveName + ".jar")
                 .addPackage(ClassLevelInterceptorTest.class.getPackage())
@@ -74,9 +65,6 @@ public class ClassLevelInterceptorTest
     @Test
     public void testClassLevelInterceptor() throws Exception
     {
-        // this test is known to not work under weld-2.0.0.Final and weld-2.0.0.SP1
-        Assume.assumeTrue(!CdiContainerUnderTest.is(CONTAINER_WELD_2_0_0));
-
         PartialBean partialBean = BeanProvider.getContextualReference(PartialBean.class);
         CustomInterceptorState state = BeanProvider.getContextualReference(CustomInterceptorState.class);
 
@@ -89,9 +77,6 @@ public class ClassLevelInterceptorTest
     @Test
     public void testClassLevelInterceptorOnAbstractMethod() throws Exception
     {
-        // this test is known to not work under weld-2.0.0.Final and weld-2.0.0.SP1
-        Assume.assumeTrue(!CdiContainerUnderTest.is(CONTAINER_WELD_2_0_0));
-
         PartialBean partialBean = BeanProvider.getContextualReference(PartialBean.class);
         CustomInterceptorState state = BeanProvider.getContextualReference(CustomInterceptorState.class);
 

--- a/deltaspike/modules/partial-bean/impl/src/test/java/org/apache/deltaspike/test/core/api/partialbean/uc013/MethodLevelCacheInterceptorTest.java
+++ b/deltaspike/modules/partial-bean/impl/src/test/java/org/apache/deltaspike/test/core/api/partialbean/uc013/MethodLevelCacheInterceptorTest.java
@@ -37,10 +37,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-public class MethodLevelInterceptorTest
+public class MethodLevelCacheInterceptorTest
 {
-    public static final String CONTAINER_WELD_2_0_0 = "weld-2\\.0\\.0\\..*";
-
     @Deployment
     public static WebArchive war()
     {
@@ -50,18 +48,11 @@ public class MethodLevelInterceptorTest
             "</class></interceptors></beans>"
         );
 
-        String simpleName = MethodLevelInterceptorTest.class.getSimpleName();
+        String simpleName = MethodLevelCacheInterceptorTest.class.getSimpleName();
         String archiveName = simpleName.substring(0, 1).toLowerCase() + simpleName.substring(1);
 
-        //don't create a completely empty web-archive
-        if (CdiContainerUnderTest.is(CONTAINER_WELD_2_0_0))
-        {
-            return ShrinkWrap.create(WebArchive.class, archiveName + ".war")
-                    .addAsLibraries(ArchiveUtils.getDeltaSpikeCoreAndPartialBeanArchive());
-        }
-
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, archiveName + ".jar")
-                .addPackage(MethodLevelInterceptorTest.class.getPackage())
+                .addPackage(MethodLevelCacheInterceptorTest.class.getPackage())
                 .addPackage(TestPartialBeanBinding.class.getPackage())
                 .addAsManifestResource(beansXml, "beans.xml");
 
@@ -75,9 +66,6 @@ public class MethodLevelInterceptorTest
     @Test
     public void testMethodLevelInterceptor() throws Exception
     {
-        // this test is known to not work under weld-2.0.0.Final and weld-2.0.0.SP1
-        Assume.assumeTrue(!CdiContainerUnderTest.is(CONTAINER_WELD_2_0_0));
-
         MyRepository myRepository = BeanProvider.getContextualReference(MyRepository.class);
 
         List<String> users = myRepository.getAllUsers();
@@ -85,7 +73,7 @@ public class MethodLevelInterceptorTest
         Assert.assertNotNull(users);
         Assert.assertEquals(3, users.size());
 
-        Assert.assertSame(users, myRepository.getAllUsers());
+        Assert.assertEquals(users, myRepository.getAllUsers());
     }
     
   

--- a/deltaspike/modules/partial-bean/impl/src/test/java/org/apache/deltaspike/test/core/api/partialbean/uc013/SimpleCacheExtension.java
+++ b/deltaspike/modules/partial-bean/impl/src/test/java/org/apache/deltaspike/test/core/api/partialbean/uc013/SimpleCacheExtension.java
@@ -26,6 +26,6 @@ public class SimpleCacheExtension implements Extension
 {
     void discoverInterceptorBindings(@Observes BeforeBeanDiscovery beforeBeanDiscoveryEvent)
     {
-        beforeBeanDiscoveryEvent.addInterceptorBinding(SimpleCache.class);
+        //beforeBeanDiscoveryEvent.addInterceptorBinding(SimpleCache.class);
     }
 }


### PR DESCRIPTION
Interceptor is not visible for DeltaSpikeProxyInterceptorLookup, so Interceptor detection will fail.
By Priority annotation the visibility is elevated to application.

Further cleanup of legacy Weld-2.0 specific handling.