### PR TITLE
import of htmlunit is missing scope test

### DIFF
--- a/deltaspike/modules/jsf/impl/pom.xml
+++ b/deltaspike/modules/jsf/impl/pom.xml
@@ -144,6 +144,7 @@
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>htmlunit3-driver</artifactId>
             <version>4.18.1</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>xml-apis</groupId>


### PR DESCRIPTION
import of htmlunit causes jsf-impl to carry dependency to web app