### PR TITLE
[bom] Remove servlet and bean validation modules from bom

### DIFF
--- a/deltaspike/dist/bom/pom.xml
+++ b/deltaspike/dist/bom/pom.xml
@@ -86,20 +86,6 @@
 
             <dependency>
                 <groupId>org.apache.deltaspike.modules</groupId>
-                <artifactId>deltaspike-servlet-module-api</artifactId>
-                <version>${project.version}</version>
-                <scope>compile</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.deltaspike.modules</groupId>
-                <artifactId>deltaspike-servlet-module-impl</artifactId>
-                <version>${project.version}</version>
-                <scope>runtime</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.deltaspike.modules</groupId>
                 <artifactId>deltaspike-jsf-module-api</artifactId>
                 <version>${project.version}</version>
                 <scope>compile</scope>
@@ -185,20 +171,6 @@
             <dependency>
                 <groupId>org.apache.deltaspike.modules</groupId>
                 <artifactId>deltaspike-test-control-module-impl</artifactId>
-                <version>${project.version}</version>
-                <scope>runtime</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.deltaspike.modules</groupId>
-                <artifactId>deltaspike-bean-validation-module-api</artifactId>
-                <version>${project.version}</version>
-                <scope>compile</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.deltaspike.modules</groupId>
-                <artifactId>deltaspike-bean-validation-module-impl</artifactId>
                 <version>${project.version}</version>
                 <scope>runtime</scope>
             </dependency>


### PR DESCRIPTION
both modules were removed from distribution.  Removing from bom as well.