### PR TITLE
[bom] Remove deltaspike-cdictrl-servlet as removed from version 2

### DIFF
--- a/deltaspike/dist/bom/pom.xml
+++ b/deltaspike/dist/bom/pom.xml
@@ -142,12 +142,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.apache.deltaspike.cdictrl</groupId>
-                <artifactId>deltaspike-cdictrl-servlet</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>org.apache.deltaspike.modules</groupId>
                 <artifactId>deltaspike-partial-bean-module-api</artifactId>
                 <version>${project.version}</version>


### PR DESCRIPTION
Missed this one as well.  This was removed in deltaspike 2.0.