### PR TITLE
DELTASPIKE-1472: Fixed: htmlunit3 dependency of deltaspike-jsf-module-impl has compile scope

### DIFF
--- a/deltaspike/modules/jsf/impl/pom.xml
+++ b/deltaspike/modules/jsf/impl/pom.xml
@@ -144,6 +144,7 @@
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>htmlunit3-driver</artifactId>
             <version>4.18.1</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>xml-apis</groupId>


### PR DESCRIPTION
Changed scope of htmlunit3-driver dependency of deltaspike-jsf-module-impl from "compile" to "test" so that the resulting tree of transitive dependencies is not included in runtime.

https://issues.apache.org/jira/browse/DELTASPIKE-1472