### PR TITLE
fix: Add required ASF policy links to footer

### DIFF
--- a/template/document.html.erb
+++ b/template/document.html.erb
@@ -270,10 +270,19 @@
     <div class="row">
         <hr>
         <footer>
-            <p>Copyright &copy; 2011-2025 The Apache Software Foundation,
-                Licensed under the Apache License, Version 2.0.</p>
-
-            <p>Apache and the Apache feather logo are trademarks of The Apache Software Foundation.</p>
+            <p>Copyright &copy; 2011-2026 The Apache Software Foundation,
+                Licensed under the <a href="https://www.apache.org/licenses/">Apache License, Version 2.0</a>.</p>
+            <p>Apache DeltaSpike, DeltaSpike, Apache, the Apache logo, and the Apache DeltaSpike project logo are either
+                registered trademarks or trademarks of The Apache Software Foundation in the United States and other countries.</p>
+            <p>
+                <a href="https://www.apache.org/">Foundation</a> |
+                <a href="https://www.apache.org/events/current-event.html">Events</a> |
+                <a href="https://www.apache.org/licenses/">License</a> |
+                <a href="https://www.apache.org/security/">Security</a> |
+                <a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a> |
+                <a href="https://www.apache.org/foundation/thanks.html">Thanks</a> |
+                <a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy</a>
+            </p>
         </footer>
     </div>
 </div>


### PR DESCRIPTION
The DeltaSpike website is failing 7 of 9 ASF website policy checks (https://whimsy.apache.org/site/):

- Foundation link (missing)
- Events (missing)
- License (was text-only, now linked)
- Thanks (missing)
- Security (missing)
- Sponsorship (missing)
- Privacy (missing)

This updates the document.html.erb template footer to include all required ASF policy links, links the license text to the canonical URL, updates copyright year to 2026, and updates the trademark text ("Apache feather logo" → "Apache logo").

See: https://www.apache.org/foundation/marks/pmcs
Checker: https://whimsy.apache.org/site/